### PR TITLE
Add Social Marketing plugin

### DIFF
--- a/social_marketing/README.rst
+++ b/social_marketing/README.rst
@@ -1,0 +1,5 @@
+Social Marketing Plugin
+=======================
+
+This addon provides basic models for managing social media accounts and posts
+within Odoo, demonstrating the structure of a marketing plugin.

--- a/social_marketing/__init__.py
+++ b/social_marketing/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/social_marketing/__manifest__.py
+++ b/social_marketing/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    'name': 'Social Marketing',
+    'version': '16.0.1.0.0',
+    'summary': 'Manage social media posts and accounts',
+    'description': 'Example module for scheduling posts and tracking basic metrics.',
+    'author': 'Example Author',
+    'category': 'Marketing',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/social_account_views.xml',
+        'views/social_post_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/social_marketing/models/__init__.py
+++ b/social_marketing/models/__init__.py
@@ -1,0 +1,2 @@
+from . import social_account
+from . import social_post

--- a/social_marketing/models/social_account.py
+++ b/social_marketing/models/social_account.py
@@ -1,0 +1,16 @@
+from odoo import models, fields
+
+
+class SocialAccount(models.Model):
+    _name = 'social.marketing.account'
+    _description = 'Social Media Account'
+
+    name = fields.Char(required=True)
+    platform = fields.Selection([
+        ('facebook', 'Facebook'),
+        ('instagram', 'Instagram'),
+        ('linkedin', 'LinkedIn'),
+        ('twitter', 'X/Twitter')
+    ], required=True)
+    access_token = fields.Char(string='Access Token')
+    active = fields.Boolean(default=True)

--- a/social_marketing/models/social_post.py
+++ b/social_marketing/models/social_post.py
@@ -1,0 +1,18 @@
+from odoo import models, fields
+
+
+class SocialPost(models.Model):
+    _name = 'social.marketing.post'
+    _description = 'Scheduled Social Post'
+
+    name = fields.Char(string='Title', required=True)
+    account_id = fields.Many2one('social.marketing.account', required=True)
+    content = fields.Text(required=True)
+    scheduled_date = fields.Datetime(string='Scheduled At')
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('scheduled', 'Scheduled'),
+        ('posted', 'Posted')
+    ], default='draft')
+    stats_impressions = fields.Integer(string='Impressions')
+    stats_clicks = fields.Integer(string='Clicks')

--- a/social_marketing/security/ir.model.access.csv
+++ b/social_marketing/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_social_marketing_account,social_marketing_account,model_social_marketing_account,base.group_user,1,1,1,1
+access_social_marketing_post,social_marketing_post,model_social_marketing_post,base.group_user,1,1,1,1

--- a/social_marketing/views/social_account_views.xml
+++ b/social_marketing/views/social_account_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_social_account_tree" model="ir.ui.view">
+        <field name="name">social.marketing.account.tree</field>
+        <field name="model">social.marketing.account</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="platform"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_social_account_form" model="ir.ui.view">
+        <field name="name">social.marketing.account.form</field>
+        <field name="model">social.marketing.account</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="platform"/>
+                        <field name="access_token"/>
+                        <field name="active"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <menuitem id="social_marketing_menu" name="Social Marketing"/>
+    <menuitem id="social_account_menu_root" name="Accounts" parent="social_marketing_menu"/>
+    <record id="action_social_account" model="ir.actions.act_window">
+        <field name="name">Social Accounts</field>
+        <field name="res_model">social.marketing.account</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem id="menu_social_account" name="Social Accounts" parent="social_account_menu_root" action="action_social_account"/>
+</odoo>

--- a/social_marketing/views/social_post_views.xml
+++ b/social_marketing/views/social_post_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_social_post_tree" model="ir.ui.view">
+        <field name="name">social.marketing.post.tree</field>
+        <field name="model">social.marketing.post</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="account_id"/>
+                <field name="scheduled_date"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_social_post_form" model="ir.ui.view">
+        <field name="name">social.marketing.post.form</field>
+        <field name="model">social.marketing.post</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="account_id"/>
+                        <field name="content"/>
+                        <field name="scheduled_date"/>
+                        <field name="state"/>
+                    </group>
+                    <group string="Statistics">
+                        <field name="stats_impressions"/>
+                        <field name="stats_clicks"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <menuitem id="social_post_menu_root" name="Posts" parent="social_marketing_menu"/>
+    <record id="action_social_post" model="ir.actions.act_window">
+        <field name="name">Social Posts</field>
+        <field name="res_model">social.marketing.post</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem id="menu_social_post" name="Social Posts" parent="social_post_menu_root" action="action_social_post"/>
+</odoo>


### PR DESCRIPTION
## Summary
- create `social_marketing` addon for Odoo
- define basic models for social accounts and posts
- add security rules and views for managing accounts and posts

## Testing
- `python3 -m py_compile social_marketing/__init__.py social_marketing/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6847fe36e16c8332bd8b9afc28248b6d