### PR TITLE
Add api decorator for scheduled posts

### DIFF
--- a/social_marketing/models/social_post.py
+++ b/social_marketing/models/social_post.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 _logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ class SocialPost(models.Model):
                 post.stats_clicks += 1
                 _logger.info("Post %s published", post.id)
 
+    @api.model
     def run_scheduled_posts(self):
         posts = self.search([
             ('state', '=', 'scheduled'),


### PR DESCRIPTION
## Summary
- update SocialPost import to include `api`
- decorate `run_scheduled_posts` with `@api.model`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68480f8ef448833294973772a117f5e2