### PR TITLE
Add moderator group for social marketing

### DIFF
--- a/social_marketing/__manifest__.py
+++ b/social_marketing/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Social Marketing',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.0.1',
     'summary': 'Manage social media posts and accounts',
     'description': 'Example module for scheduling posts and tracking basic metrics.',
     'author': 'Example Author',

--- a/social_marketing/security/ir.model.access.csv
+++ b/social_marketing/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_social_marketing_account,social_marketing_account,model_social_marketing_account,base.group_user,1,1,1,1
 access_social_marketing_post,social_marketing_post,model_social_marketing_post,base.group_user,1,1,1,1
+access_mail_message_social_moderator,mail_message_social_moderator,mail.model_mail_message,social_marketing.group_social_marketing_moderator,1,1,1,0

--- a/social_marketing/security/social_marketing_security.xml
+++ b/social_marketing/security/social_marketing_security.xml
@@ -12,4 +12,9 @@
         <field name="name">Social Marketing Analyst</field>
         <field name="category_id" ref="base.module_category_marketing"/>
     </record>
+    <record id="group_social_marketing_moderator" model="res.groups">
+        <field name="name">Social Marketing Moderator</field>
+        <field name="category_id" ref="base.module_category_marketing"/>
+        <field name="implied_ids" eval="[(4, ref('group_social_marketing_analyst'))]"/>
+    </record>
 </odoo>


### PR DESCRIPTION
## Summary
- create new `group_social_marketing_moderator`
- allow moderators to reply to messages
- bump module version

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684811ccfce08332989d52a6b7f57dd1