### PR TITLE
Secure social account token field

### DIFF
--- a/social_marketing/models/social_account.py
+++ b/social_marketing/models/social_account.py
@@ -12,5 +12,5 @@ class SocialAccount(models.Model):
         ('linkedin', 'LinkedIn'),
         ('twitter', 'X/Twitter')
     ], required=True)
-    access_token = fields.Char(string='Access Token')
+    access_token = fields.Char(string='Access Token', password=True)
     active = fields.Boolean(default=True)

--- a/social_marketing/views/social_account_views.xml
+++ b/social_marketing/views/social_account_views.xml
@@ -20,7 +20,7 @@
                     <group>
                         <field name="name"/>
                         <field name="platform"/>
-                        <field name="access_token"/>
+                        <field name="access_token" password="True"/>
                         <field name="active"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
## Summary
- mark social account token as password field
- update form to render token as password input

## Testing
- `python -m compileall social_marketing/models/social_account.py`

------
https://chatgpt.com/codex/tasks/task_e_684811cd60d48332b1280af4961d90ba