### PR TITLE
Add multi-company support to social_marketing

### DIFF
--- a/social_marketing/models/social_account.py
+++ b/social_marketing/models/social_account.py
@@ -14,3 +14,5 @@ class SocialAccount(models.Model):
     ], required=True)
     access_token = fields.Char(string='Access Token')
     active = fields.Boolean(default=True)
+    company_id = fields.Many2one('res.company', required=True,
+                                 default=lambda self: self.env.company)

--- a/social_marketing/models/social_post.py
+++ b/social_marketing/models/social_post.py
@@ -21,6 +21,8 @@ class SocialPost(models.Model):
     ], default='draft')
     stats_impressions = fields.Integer(string='Impressions')
     stats_clicks = fields.Integer(string='Clicks')
+    company_id = fields.Many2one('res.company', required=True,
+                                 default=lambda self: self.env.company)
 
     def post_now(self):
         """Post the content immediately and update statistics."""
@@ -36,7 +38,8 @@ class SocialPost(models.Model):
     def run_scheduled_posts(self):
         posts = self.search([
             ('state', '=', 'scheduled'),
-            ('scheduled_date', '<=', fields.Datetime.now())
+            ('scheduled_date', '<=', fields.Datetime.now()),
+            ('company_id', '=', self.env.company.id)
         ])
         posts.post_now()
 

--- a/social_marketing/security/social_marketing_security.xml
+++ b/social_marketing/security/social_marketing_security.xml
@@ -12,4 +12,16 @@
         <field name="name">Social Marketing Analyst</field>
         <field name="category_id" ref="base.module_category_marketing"/>
     </record>
+    <record id="social_account_rule_company" model="ir.rule">
+        <field name="name">Social Account multi-company</field>
+        <field name="model_id" ref="model_social_marketing_account"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', user.company_ids.ids)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+    <record id="social_post_rule_company" model="ir.rule">
+        <field name="name">Social Post multi-company</field>
+        <field name="model_id" ref="model_social_marketing_post"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', user.company_ids.ids)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    </record>
 </odoo>

--- a/social_marketing/views/social_account_views.xml
+++ b/social_marketing/views/social_account_views.xml
@@ -8,6 +8,7 @@
                 <field name="name"/>
                 <field name="platform"/>
                 <field name="active"/>
+                <field name="company_id"/>
             </tree>
         </field>
     </record>
@@ -22,6 +23,7 @@
                         <field name="platform"/>
                         <field name="access_token"/>
                         <field name="active"/>
+                        <field name="company_id"/>
                     </group>
                 </sheet>
             </form>

--- a/social_marketing/views/social_post_views.xml
+++ b/social_marketing/views/social_post_views.xml
@@ -9,6 +9,7 @@
                 <field name="account_id"/>
                 <field name="scheduled_date"/>
                 <field name="state"/>
+                <field name="company_id"/>
             </tree>
         </field>
     </record>
@@ -24,6 +25,7 @@
                         <field name="content"/>
                         <field name="scheduled_date"/>
                         <field name="state"/>
+                        <field name="company_id"/>
                         <button string="Post Now" type="object" name="post_now" states="draft,scheduled" class="btn-primary"/>
                     </group>
                     <group string="Statistics">


### PR DESCRIPTION
## Summary
- add company_id to SocialAccount and SocialPost models
- add company_id to SocialAccount and SocialPost views
- restrict record access by company
- filter scheduled posts by company

## Testing
- `python3 -m py_compile $(git ls-files "*.py")`

------
https://chatgpt.com/codex/tasks/task_e_684811ce23248332835dbe3338092194