### PR TITLE
Fix scheduled posts filtering and tests

### DIFF
--- a/social_marketing/tests/test_posting.py
+++ b/social_marketing/tests/test_posting.py
@@ -90,4 +90,5 @@ def test_run_scheduled_posts_ignores_future_items(monkeypatch):
     SocialPost().run_scheduled_posts()
 
     assert post.state == 'scheduled'
-    assert post.stats_i_
+    assert post.stats_impressions == 0
+    assert post.stats_clicks == 0


### PR DESCRIPTION
## Summary
- handle list-based search results in `run_scheduled_posts`
- fix unit tests for future-dated posts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481809b770833284e88e0cedd3d4aa