### PR TITLE
Add dummy Odoo fields and depends decorator

### DIFF
--- a/base_plugin/tests/test_field_types.py
+++ b/base_plugin/tests/test_field_types.py
@@ -1,0 +1,35 @@
+import datetime
+from odoo import models, fields, api
+
+
+def test_fields_module_contains_new_types():
+    assert hasattr(fields, "Float")
+    assert hasattr(fields, "Date")
+    assert hasattr(fields, "Many2many")
+    assert hasattr(fields, "One2many")
+
+
+class DummyModel(models.Model):
+    _name = 'dummy.model'
+
+    float_field = fields.Float()
+    date_field = fields.Date()
+    many_ids = fields.Many2many('dummy.model')
+    one_ids = fields.One2many('dummy.model', 'parent_id')
+    parent_id = fields.Many2one('dummy.model')
+
+    def __init__(self, **vals):
+        super().__init__(**vals)
+        self.double = 0
+
+    @api.depends('float_field')
+    def compute_double(self):
+        self.double = self.float_field * 2
+
+
+def test_api_depends_and_fields_usage():
+    rec = DummyModel(float_field=2.5, date_field=datetime.date.today())
+    rec.compute_double()
+    assert rec.double == 5.0
+    assert getattr(DummyModel.compute_double, '_depends') == ('float_field',)
+

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,12 @@ class _DatetimeField(_Field):
     def now():
         return datetime.datetime.now()
 
+
+class _DateField(_Field):
+    @staticmethod
+    def today():
+        return datetime.date.today()
+
 # Champs typés pour compatibilité avec Odoo
 class Char(_Field): pass
 class Many2one(_Field): pass
@@ -22,6 +28,9 @@ class Text(_Field): pass
 class Selection(_Field): pass
 class Integer(_Field): pass
 class Boolean(_Field): pass
+class Float(_Field): pass
+class Many2many(_Field): pass
+class One2many(_Field): pass
 
 # Enveloppe fields
 fields_mod = types.ModuleType('odoo.fields')
@@ -32,10 +41,29 @@ fields_mod.Selection = Selection
 fields_mod.Integer = Integer
 fields_mod.Boolean = Boolean
 fields_mod.Datetime = _DatetimeField
+fields_mod.Date = _DateField
+fields_mod.Float = Float
+fields_mod.Many2many = Many2many
+fields_mod.One2many = One2many
 
 # Décorateurs API simulés
 api_mod = types.ModuleType('odoo.api')
 api_mod.model = lambda f: f
+
+
+def _store_args(attr):
+    def decorator(*fields):
+        def wrapper(func):
+            setattr(func, attr, fields)
+            return func
+        return wrapper
+    return decorator
+
+
+api_mod.depends = _store_args('_depends')
+api_mod.onchange = _store_args('_onchange')
+api_mod.constrains = _store_args('_constrains')
+api_mod.model_create_multi = lambda f: f
 
 # RecordSet simulé (comme un ORM Odoo)
 class RecordSet(list):


### PR DESCRIPTION
## Summary
- extend the mocked Odoo env with Float, Date, Many2many and One2many
- store args for api.depends/onchange/constrains
- add regression tests showing usage of the new field types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848288038908332b99ba636a96c359c