### PR TITLE
Use shared stub in social marketing tests

### DIFF
--- a/social_marketing/tests/test_posting.py
+++ b/social_marketing/tests/test_posting.py
@@ -1,55 +1,21 @@
 import datetime
-import types
 import importlib
-import sys
 
 import pytest
 
 
-def setup_module(module):
-    """Stub minimal des modules Odoo pour exécuter les tests."""
-    odoo = types.ModuleType('odoo')
-    models_mod = types.ModuleType('odoo.models')
-    class Model: pass
-    models_mod.Model = Model
-
-    fields_mod = types.ModuleType('odoo.fields')
-    class _Datetime:
-        @staticmethod
-        def now():
-            return datetime.datetime.now()
-    fields_mod.Char = object
-    fields_mod.Many2one = object
-    fields_mod.Text = object
-    fields_mod.Selection = object
-    fields_mod.Integer = object
-    fields_mod.Datetime = _Datetime
-
-    api_mod = types.ModuleType('odoo.api')
-    api_mod.model = lambda func: func
-
-    odoo.models = models_mod
-    odoo.fields = fields_mod
-    odoo.api = api_mod
-
-    sys.modules.setdefault('odoo', odoo)
-    sys.modules.setdefault('odoo.models', models_mod)
-    sys.modules.setdefault('odoo.fields', fields_mod)
-    sys.modules.setdefault('odoo.api', api_mod)
-
-    importlib.invalidate_caches()
-
-
 @pytest.fixture(autouse=True)
-def reset_registry():
-    from social_marketing.models import social_post
-    social_post.SocialPost._registry = []
-
-
-def test_run_scheduled_posts_posts_due_items(monkeypatch):
+def social_post_class():
+    """Reload SocialPost and reset its registry for each test."""
     from social_marketing.models import social_post
     importlib.reload(social_post)
-    SocialPost = social_post.SocialPost
+    social_post.SocialPost._registry = []
+    social_post.models.Model._id_seq = 1
+    return social_post.SocialPost
+
+
+def test_run_scheduled_posts_posts_due_items(social_post_class, monkeypatch):
+    SocialPost = social_post_class
 
     post = SocialPost(
         name='test',
@@ -70,10 +36,8 @@ def test_run_scheduled_posts_posts_due_items(monkeypatch):
     assert post.stats_clicks == 1
 
 
-def test_run_scheduled_posts_ignores_future_items(monkeypatch):
-    from social_marketing.models import social_post
-    importlib.reload(social_post)
-    SocialPost = social_post.SocialPost
+def test_run_scheduled_posts_ignores_future_items(social_post_class, monkeypatch):
+    SocialPost = social_post_class
 
     post = SocialPost(
         name='future',


### PR DESCRIPTION
## Summary
- drop custom stub setup from `social_marketing` tests
- reload `SocialPost` through a fixture so imports happen after `conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848288180f083329342e38ddc47de3a