### PR TITLE
Add SocialPost post_now test

### DIFF
--- a/social_marketing/tests/test_posting.py
+++ b/social_marketing/tests/test_posting.py
@@ -92,3 +92,37 @@ def test_run_scheduled_posts_ignores_future_items(monkeypatch):
     assert post.state == 'scheduled'
     assert post.stats_impressions == 0
     assert post.stats_clicks == 0
+
+
+def test_post_now_updates_states_and_counters():
+    from social_marketing.models import social_post
+    importlib.reload(social_post)
+    SocialPost = social_post.SocialPost
+
+    draft = SocialPost(
+        name='draft',
+        account_id=None,
+        content='demo',
+        scheduled_date=datetime.datetime.now(),
+        state='draft',
+        stats_impressions=2,
+        stats_clicks=3,
+    )
+    scheduled = SocialPost(
+        name='scheduled',
+        account_id=None,
+        content='demo',
+        scheduled_date=datetime.datetime.now(),
+        state='scheduled',
+        stats_impressions=1,
+        stats_clicks=4,
+    )
+
+    SocialPost.post_now([draft, scheduled])
+
+    assert draft.state == 'posted'
+    assert scheduled.state == 'posted'
+    assert draft.stats_impressions == 3
+    assert draft.stats_clicks == 4
+    assert scheduled.stats_impressions == 2
+    assert scheduled.stats_clicks == 5


### PR DESCRIPTION
## Summary
- test SocialPost.post_now transitions posts and increments counters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482a965e108332b555a3be59ba5e29