### PR TITLE
Add reusable SocialPost fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import datetime
+import pytest
 
 # Crée un module simulé "odoo"
 odoo = types.ModuleType('odoo')
@@ -119,3 +120,12 @@ sys.modules.setdefault('odoo', odoo)
 sys.modules.setdefault('odoo.models', models_mod)
 sys.modules.setdefault('odoo.fields', fields_mod)
 sys.modules.setdefault('odoo.api', api_mod)
+
+
+@pytest.fixture
+def social_post_class():
+    import importlib
+    from social_marketing.models import social_post
+    importlib.reload(social_post)
+    social_post.SocialPost._registry = []
+    return social_post.SocialPost

--- a/social_marketing/tests/test_posting.py
+++ b/social_marketing/tests/test_posting.py
@@ -1,17 +1,4 @@
 import datetime
-import importlib
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def social_post_class():
-    """Reload SocialPost and reset its registry for each test."""
-    from social_marketing.models import social_post
-    importlib.reload(social_post)
-    social_post.SocialPost._registry = []
-    social_post.models.Model._id_seq = 1
-    return social_post.SocialPost
 
 
 def test_run_scheduled_posts_posts_due_items(social_post_class, monkeypatch):
@@ -58,10 +45,8 @@ def test_run_scheduled_posts_ignores_future_items(social_post_class, monkeypatch
     assert post.stats_clicks == 0
 
 
-def test_post_now_updates_states_and_counters():
-    from social_marketing.models import social_post
-    importlib.reload(social_post)
-    SocialPost = social_post.SocialPost
+def test_post_now_updates_states_and_counters(social_post_class):
+    SocialPost = social_post_class
 
     draft = SocialPost(
         name='draft',


### PR DESCRIPTION
## Summary
- add `social_post_class` fixture to `conftest.py`
- use fixture in tests to reload module and reset registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482e7a597c8332a7aee8592aa278a6