### PR TITLE
Fix id sequence reset in social_post_class fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -128,4 +128,5 @@ def social_post_class():
     from social_marketing.models import social_post
     importlib.reload(social_post)
     social_post.SocialPost._registry = []
+    social_post.models.Model._id_seq = 1
     return social_post.SocialPost


### PR DESCRIPTION
## Summary
- ensure social_post fixtures reset the Model id sequence after reload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483122787c833286b41c7a9cb717d3