### PR TITLE
Add accounting anomaly analysis addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This repository contains example Odoo addons.
 
 - `base_plugin`: Minimal plugin demonstrating the basic structure of an Odoo module.
 - `social_marketing`: Example plugin for managing social media accounts and posts with scheduling and basic tracking.
+- `account_anomaly`: Simple addon for flagging unusual accounting moves.
 - Make sure the scheduled action defined in [`social_marketing/data/scheduled_actions.xml`](social_marketing/data/scheduled_actions.xml) is enabled so scheduled posts are processed automatically.
 
 ## Installation
 
-1. Copy the addon directories (e.g. `base_plugin`, `social_marketing`) into your Odoo `addons_path`.
+1. Copy the addon directories (e.g. `base_plugin`, `social_marketing`, `account_anomaly`) into your Odoo `addons_path`.
 2. Update the Apps list inside Odoo.
 3. Install the desired addon from the Apps menu.
 
-These addons require **Odoo&nbsp;16** for compatibility. See [`social_marketing/__manifest__.py`](social_marketing/__manifest__.py) for additional module metadata.
+These addons require **Odoo&nbsp;16** for compatibility. See [`social_marketing/__manifest__.py`](social_marketing/__manifest__.py) and [`account_anomaly/__manifest__.py`](account_anomaly/__manifest__.py) for additional module metadata.
 
 ## Running tests
 

--- a/account_anomaly/README.rst
+++ b/account_anomaly/README.rst
@@ -1,0 +1,22 @@
+Accounting Anomaly Plugin
+=========================
+
+This addon provides a simple model for storing accounting moves and helper
+functions to detect unusual entries.  A move is considered anomalous when
+its amount is negative or exceeds a configurable threshold (default 10,000).
+
+Main Files
+----------
+
+- ``models/account_move.py`` – defines ``account.anomaly.move`` with a few
+  basic fields and anomaly detection logic.
+- ``views/account_move_views.xml`` – example tree and form views so records
+  can be managed from the Odoo interface.
+- ``security/ir.model.access.csv`` – grants CRUD access to internal users.
+
+Usage Example
+-------------
+
+Detect anomalies programmatically::
+
+    AccountMove.find_anomalies(threshold=5000.0)

--- a/account_anomaly/__init__.py
+++ b/account_anomaly/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+
+__all__ = ["models"]

--- a/account_anomaly/__manifest__.py
+++ b/account_anomaly/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Accounting Anomaly',
+    'version': '16.0.1.0.0',
+    'summary': 'Analyze accounting moves for anomalies',
+    'description': 'Simple tools to detect unusual accounting entries.',
+    'author': 'Example Author',
+    'category': 'Accounting',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/account_move_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/account_anomaly/models/__init__.py
+++ b/account_anomaly/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_move
+
+__all__ = ["account_move"]

--- a/account_anomaly/models/account_move.py
+++ b/account_anomaly/models/account_move.py
@@ -1,0 +1,20 @@
+from odoo import models, fields
+
+
+class AccountMove(models.Model):
+    _name = 'account.anomaly.move'
+    _description = 'Accounting Move'
+
+    name = fields.Char(required=True)
+    amount = fields.Float(required=True)
+    date = fields.Date(default=fields.Date.today)
+    is_anomaly = fields.Boolean(string='Anomaly', default=False)
+
+    @classmethod
+    def find_anomalies(cls, threshold=10000.0):
+        """Return moves with negative amounts or exceeding ``threshold``."""
+        anomalies = []
+        for rec in cls._registry:
+            if rec.amount < 0 or rec.amount > threshold:
+                anomalies.append(rec)
+        return anomalies

--- a/account_anomaly/security/ir.model.access.csv
+++ b/account_anomaly/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_anomaly_move,access_account_anomaly_move,model_account_anomaly_move,base.group_user,1,1,1,1

--- a/account_anomaly/tests/test_anomaly_detection.py
+++ b/account_anomaly/tests/test_anomaly_detection.py
@@ -1,0 +1,23 @@
+import datetime
+
+
+def test_find_anomalies_detects_unusual_moves(account_move_class):
+    AccountMove = account_move_class
+    neg = AccountMove(name='neg', amount=-5, date=datetime.date.today())
+    big = AccountMove(name='big', amount=20000, date=datetime.date.today())
+    ok = AccountMove(name='ok', amount=100, date=datetime.date.today())
+
+    result = AccountMove.find_anomalies()
+
+    assert neg in result
+    assert big in result
+    assert ok not in result
+
+
+def test_find_anomalies_uses_threshold(account_move_class):
+    AccountMove = account_move_class
+    mid = AccountMove(name='mid', amount=5000, date=datetime.date.today())
+
+    result = AccountMove.find_anomalies(threshold=4000)
+
+    assert mid in result

--- a/account_anomaly/views/account_move_views.xml
+++ b/account_anomaly/views/account_move_views.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_account_move_tree" model="ir.ui.view">
+        <field name="name">account.anomaly.move.tree</field>
+        <field name="model">account.anomaly.move</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="amount"/>
+                <field name="is_anomaly"/>
+                <field name="date"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_account_move_form" model="ir.ui.view">
+        <field name="name">account.anomaly.move.form</field>
+        <field name="model">account.anomaly.move</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="amount"/>
+                        <field name="date"/>
+                        <field name="is_anomaly"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <menuitem id="account_anomaly_menu" name="Accounting Anomaly"/>
+    <menuitem id="account_anomaly_menu_root" name="Moves" parent="account_anomaly_menu"/>
+    <record id="action_account_move" model="ir.actions.act_window">
+        <field name="name">Accounting Moves</field>
+        <field name="res_model">account.anomaly.move</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem id="menu_account_move" name="Moves" parent="account_anomaly_menu_root" action="action_account_move"/>
+</odoo>

--- a/conftest.py
+++ b/conftest.py
@@ -130,3 +130,13 @@ def social_post_class():
     social_post.SocialPost._registry = []
     social_post.models.Model._id_seq = 1
     return social_post.SocialPost
+
+
+@pytest.fixture
+def account_move_class():
+    import importlib
+    from account_anomaly.models import account_move
+    importlib.reload(account_move)
+    account_move.AccountMove._registry = []
+    account_move.models.Model._id_seq = 1
+    return account_move.AccountMove


### PR DESCRIPTION
## Summary
- add an `account_anomaly` module with a simple model to find unusual accounting entries
- extend documentation to mention the new addon
- include tests for anomaly detection logic
- update `conftest.py` with an `account_move_class` fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867da294c68833280c940ef3211fdc5