### PR TITLE
Add skeleton Belgian fiscal module

### DIFF
--- a/l10n_be_fiscal_full/README.rst
+++ b/l10n_be_fiscal_full/README.rst
@@ -1,0 +1,12 @@
+Belgian Fiscal Declarations
+==========================
+
+This addon provides a minimal skeleton for handling Belgian fiscal
+declarations in Odoo. It defines a single model ``be.fiscal.declaration``
+that can represent different types of filings such as VAT returns,
+client listings, Belcotax forms, ISOC statements and XBRL exports.
+
+The ``generate_xml`` method creates a simplistic XML snippet while
+``export_xml`` marks the declaration as exported. The implementation is
+intended as a starting point for a complete solution that would follow
+official specifications and integrate with Intervat, Belcotax or Biztax.

--- a/l10n_be_fiscal_full/__init__.py
+++ b/l10n_be_fiscal_full/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_be_fiscal_full/__manifest__.py
+++ b/l10n_be_fiscal_full/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Belgian Fiscal Declarations',
+    'version': '16.0.1.0.0',
+    'summary': 'Generate Belgian fiscal reports and exports',
+    'description': 'Skeleton module for Belgian fiscal declarations (TVA, Belcotax, ISOC, BNB).',
+    'author': 'Example Author',
+    'category': 'Accounting',
+    'depends': ['base'],
+    'data': [],
+    'installable': True,
+    'application': True,
+}

--- a/l10n_be_fiscal_full/models/__init__.py
+++ b/l10n_be_fiscal_full/models/__init__.py
@@ -1,0 +1,1 @@
+from . import declaration

--- a/l10n_be_fiscal_full/models/declaration.py
+++ b/l10n_be_fiscal_full/models/declaration.py
@@ -1,0 +1,42 @@
+from odoo import models, fields
+
+
+class FiscalDeclaration(models.Model):
+    _name = 'be.fiscal.declaration'
+    _description = 'Belgian Fiscal Declaration'
+
+    name = fields.Char(required=True)
+    declaration_type = fields.Selection([
+        ('vat', 'VAT'),
+        ('listing', 'Client Listing'),
+        ('belcotax', 'Belcotax'),
+        ('isoc', 'ISOC'),
+        ('xbrl', 'XBRL')
+    ], required=True)
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('ready', 'Ready'),
+        ('exported', 'Exported')
+    ], default='draft')
+    xml_content = fields.Text(string='XML Content')
+
+    def _iterate(self):
+        """Return a list of records for uniform iteration."""
+        return self if isinstance(self, (list, tuple)) else [self]
+
+    def generate_xml(self):
+        """Generate a very basic XML representation for the declaration."""
+        for rec in self._iterate():
+            rec.xml_content = (
+                f"<declaration type='{rec.declaration_type}' name='{rec.name}'/>"
+            )
+            rec.state = 'ready'
+        return getattr(self, 'xml_content', None)
+
+    def export_xml(self):
+        """Mark the declaration as exported and return its XML."""
+        for rec in self._iterate():
+            if rec.state != 'ready':
+                rec.generate_xml()
+            rec.state = 'exported'
+        return getattr(self, 'xml_content', None)

--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+def test_generate_xml_sets_content_and_state(monkeypatch):
+    from l10n_be_fiscal_full.models import declaration
+    import importlib
+    importlib.reload(declaration)
+    declaration.FiscalDeclaration._registry = []
+    declaration.models.Model._id_seq = 1
+
+    dec = declaration.FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
+
+    dec.generate_xml()
+
+    assert dec.xml_content.startswith('<declaration')
+    assert dec.state == 'ready'
+
+
+def test_export_xml_marks_exported(monkeypatch):
+    from l10n_be_fiscal_full.models import declaration
+    import importlib
+    importlib.reload(declaration)
+    declaration.FiscalDeclaration._registry = []
+    declaration.models.Model._id_seq = 1
+
+    dec = declaration.FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
+
+    dec.export_xml()
+
+    assert dec.state == 'exported'
+    assert dec.xml_content.startswith('<declaration')


### PR DESCRIPTION
## Summary
- add `l10n_be_fiscal_full` module skeleton
- implement `be.fiscal.declaration` model
- document the addon and provide basic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e3364e18c8332a216a6785f3159d2