### PR TITLE
Add fixture for FiscalDeclaration tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -140,3 +140,13 @@ def account_move_class():
     account_move.AccountMove._registry = []
     account_move.models.Model._id_seq = 1
     return account_move.AccountMove
+
+
+@pytest.fixture
+def fiscal_declaration_class():
+    import importlib
+    from l10n_be_fiscal_full.models import declaration
+    importlib.reload(declaration)
+    declaration.FiscalDeclaration._registry = []
+    declaration.models.Model._id_seq = 1
+    return declaration.FiscalDeclaration

--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -1,14 +1,10 @@
 import pytest
 
 
-def test_generate_xml_sets_content_and_state(monkeypatch):
-    from l10n_be_fiscal_full.models import declaration
-    import importlib
-    importlib.reload(declaration)
-    declaration.FiscalDeclaration._registry = []
-    declaration.models.Model._id_seq = 1
+def test_generate_xml_sets_content_and_state(fiscal_declaration_class, monkeypatch):
+    FiscalDeclaration = fiscal_declaration_class
 
-    dec = declaration.FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
+    dec = FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
 
     dec.generate_xml()
 
@@ -16,14 +12,10 @@ def test_generate_xml_sets_content_and_state(monkeypatch):
     assert dec.state == 'ready'
 
 
-def test_export_xml_marks_exported(monkeypatch):
-    from l10n_be_fiscal_full.models import declaration
-    import importlib
-    importlib.reload(declaration)
-    declaration.FiscalDeclaration._registry = []
-    declaration.models.Model._id_seq = 1
+def test_export_xml_marks_exported(fiscal_declaration_class, monkeypatch):
+    FiscalDeclaration = fiscal_declaration_class
 
-    dec = declaration.FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
+    dec = FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
 
     dec.export_xml()
 


### PR DESCRIPTION
## Summary
- add fixture `fiscal_declaration_class` to `conftest.py`
- use fixture in declaration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5fe66cc88332b02457aee94c0293