### PR TITLE
Add flake8/black linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,5 +16,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run linters
+        run: |
+          black --check .
+          flake8
       - name: Run tests
         run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 pytest>=7.0
+
+flake8
+black


### PR DESCRIPTION
## Summary
- install flake8 and black
- configure minimal lint settings
- run linting in CI before tests

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `black --check .` *(fails: would reformat many files)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a4a915c833285ce73de6832bdfd