### PR TITLE
Add list-based XML tests

### DIFF
--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -21,3 +21,31 @@ def test_export_xml_marks_exported(fiscal_declaration_class, monkeypatch):
 
     assert dec.state == 'exported'
     assert dec.xml_content.startswith('<declaration')
+
+
+def test_generate_and_export_on_list(fiscal_declaration_class):
+    """Methods should operate on lists of declarations."""
+    FiscalDeclaration = fiscal_declaration_class
+
+    dec1 = FiscalDeclaration(name='Q1 VAT', declaration_type='vat')
+    dec2 = FiscalDeclaration(name='Client Listing', declaration_type='listing')
+
+    class RecordList(list):
+        def _iterate(self):
+            return self
+
+    records = RecordList([dec1, dec2])
+
+    FiscalDeclaration.generate_xml(records)
+
+    assert dec1.state == 'ready'
+    assert dec2.state == 'ready'
+    assert dec1.xml_content.startswith('<declaration')
+    assert dec2.xml_content.startswith('<declaration')
+
+    FiscalDeclaration.export_xml(records)
+
+    assert dec1.state == 'exported'
+    assert dec2.state == 'exported'
+    assert dec1.xml_content.startswith('<declaration')
+    assert dec2.xml_content.startswith('<declaration')


### PR DESCRIPTION
## Summary
- test generating and exporting XML over a list of declarations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6a483a148332825f004230b13753