### PR TITLE
Add Belcotax export wizard

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -160,3 +160,14 @@ def lu_fiscal_declaration_class():
     declaration.FiscalDeclaration._registry = []
     declaration.models.Model._id_seq = 1
     return declaration.FiscalDeclaration
+
+
+@pytest.fixture
+def belcotax_export_wizard_class():
+    import importlib
+    from l10n_be_fiscal_full.wizards import belcotax_export_wizard
+    importlib.reload(belcotax_export_wizard)
+    belcotax_export_wizard.BelcotaxExportWizard._registry = []
+    belcotax_export_wizard.models.Model._id_seq = 1
+    return belcotax_export_wizard.BelcotaxExportWizard
+

--- a/l10n_be_fiscal_full/__init__.py
+++ b/l10n_be_fiscal_full/__init__.py
@@ -1,3 +1,4 @@
-from . import models
+from . import models, wizards
 
-__all__ = ["models"]
+__all__ = ["models", "wizards"]
+

--- a/l10n_be_fiscal_full/__manifest__.py
+++ b/l10n_be_fiscal_full/__manifest__.py
@@ -6,7 +6,10 @@
     'author': 'Example Author',
     'category': 'Accounting',
     'depends': ['base'],
-    'data': [],
+    'data': [
+        'views/belcotax_wizard_views.xml',
+    ],
     'installable': True,
     'application': True,
 }
+

--- a/l10n_be_fiscal_full/models/declaration.py
+++ b/l10n_be_fiscal_full/models/declaration.py
@@ -18,6 +18,7 @@ class FiscalDeclaration(models.Model):
         ('ready', 'Ready'),
         ('exported', 'Exported')
     ], default='draft')
+    exported_date = fields.Date(string='Exported On')
     xml_content = fields.Text(string='XML Content')
 
     def _iterate(self):
@@ -39,4 +40,6 @@ class FiscalDeclaration(models.Model):
             if rec.state != 'ready':
                 rec.generate_xml()
             rec.state = 'exported'
+            rec.exported_date = fields.Date.today()
         return getattr(self, 'xml_content', None)
+

--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -1,4 +1,5 @@
 import pytest
+from odoo.fields import Date
 
 
 def test_generate_xml_sets_content_and_state(fiscal_declaration_class, monkeypatch):
@@ -21,6 +22,7 @@ def test_export_xml_marks_exported(fiscal_declaration_class, monkeypatch):
 
     assert dec.state == 'exported'
     assert dec.xml_content.startswith('<declaration')
+    assert dec.exported_date == Date.today()
 
 
 def test_generate_and_export_on_list(fiscal_declaration_class):
@@ -49,3 +51,5 @@ def test_generate_and_export_on_list(fiscal_declaration_class):
     assert dec2.state == 'exported'
     assert dec1.xml_content.startswith('<declaration')
     assert dec2.xml_content.startswith('<declaration')
+    assert dec1.exported_date == Date.today()
+    assert dec2.exported_date == Date.today()

--- a/l10n_be_fiscal_full/tests/test_wizard.py
+++ b/l10n_be_fiscal_full/tests/test_wizard.py
@@ -1,0 +1,35 @@
+import base64
+from odoo.fields import Date
+
+
+def test_belcotax_wizard_returns_act_url(belcotax_export_wizard_class, monkeypatch):
+    Wizard = belcotax_export_wizard_class
+
+    class DummyDeclaration:
+        last = None
+
+        def __init__(self, **vals):
+            DummyDeclaration.last = self
+            self.exported_date = None
+            self.state = 'draft'
+
+        def generate_xml(self):
+            return '<xml/>'
+
+        def export_xml(self):
+            self.state = 'exported'
+            self.exported_date = Date.today()
+            return '<xml/>'
+
+    module = __import__(Wizard.__module__, fromlist=[''])
+    monkeypatch.setattr(module, 'FiscalDeclaration', DummyDeclaration)
+
+    wiz = Wizard(fiscal_year='2022', form_type='281.10')
+    result = wiz.action_export()
+
+    assert result['type'] == 'ir.actions.act_url'
+    assert result['url'].startswith('data:text/xml;base64,')
+    data = result['url'].split(',', 1)[1]
+    assert base64.b64decode(data).decode() == '<xml/>'
+    assert DummyDeclaration.last.exported_date == Date.today()
+

--- a/l10n_be_fiscal_full/views/belcotax_wizard_views.xml
+++ b/l10n_be_fiscal_full/views/belcotax_wizard_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_belcotax_export_wizard" model="ir.ui.view">
+        <field name="name">belcotax.export.wizard.form</field>
+        <field name="model">belcotax.export.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Belcotax Export">
+                <group>
+                    <field name="fiscal_year"/>
+                    <field name="form_type"/>
+                </group>
+                <footer>
+                    <button string="Export" type="object" name="action_export" class="btn-primary"/>
+                    <button string="Cancel" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_belcotax_export_wizard" model="ir.actions.act_window">
+        <field name="name">Belcotax Export</field>
+        <field name="res_model">belcotax.export.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_belgian_fiscal_root" name="Belgian Fiscal"/>
+    <menuitem id="menu_belcotax_export" name="Belcotax Export" parent="menu_belgian_fiscal_root" action="action_belcotax_export_wizard"/>
+</odoo>
+

--- a/l10n_be_fiscal_full/wizards/__init__.py
+++ b/l10n_be_fiscal_full/wizards/__init__.py
@@ -1,0 +1,4 @@
+from . import belcotax_export_wizard
+
+__all__ = ["belcotax_export_wizard"]
+

--- a/l10n_be_fiscal_full/wizards/belcotax_export_wizard.py
+++ b/l10n_be_fiscal_full/wizards/belcotax_export_wizard.py
@@ -1,0 +1,31 @@
+from odoo import models, fields
+import base64
+
+from ..models.declaration import FiscalDeclaration
+
+
+class BelcotaxExportWizard(models.Model):
+    _name = 'belcotax.export.wizard'
+    _description = 'Belcotax Export Wizard'
+
+    fiscal_year = fields.Char(string='Fiscal Year', required=True)
+    form_type = fields.Selection([
+        ('281.10', '281.10'),
+        ('281.30', '281.30'),
+    ], string='Form Type', required=True)
+
+    def action_export(self):
+        """Generate XML and return it as a downloadable URL."""
+        dec = FiscalDeclaration(
+            name=f'Belcotax {self.fiscal_year}',
+            declaration_type='belcotax'
+        )
+        xml = dec.generate_xml()
+        dec.export_xml()
+        data = base64.b64encode(xml.encode('utf-8')).decode('ascii')
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'data:text/xml;base64,{data}',
+            'target': 'new',
+        }
+


### PR DESCRIPTION
## Summary
- add a simple wizard to export Belcotax XML
- store exported date on declarations
- integrate wizard menu and views
- test the wizard and export state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcd537bdc833281a9fa3df5170dfd