### PR TITLE
Add partner link for belcotax lines

### DIFF
--- a/l10n_be_fiscal_full/models/__init__.py
+++ b/l10n_be_fiscal_full/models/__init__.py
@@ -1,1 +1,3 @@
 from . import declaration
+from . import belcotax_line
+from . import res_partner

--- a/l10n_be_fiscal_full/models/belcotax_line.py
+++ b/l10n_be_fiscal_full/models/belcotax_line.py
@@ -1,0 +1,21 @@
+from odoo import models, fields
+
+
+class BelcotaxDeclarationLine(models.Model):
+    _name = 'belcotax.declaration.line'
+    _description = 'Belcotax Declaration Line'
+
+    declaration_id = fields.Many2one('be.fiscal.declaration', required=True)
+    partner_id = fields.Many2one('res.partner', string='Partner')
+    amount = fields.Float()
+
+    def get_partner_vat(self):
+        partner = getattr(self, 'partner_id', None)
+        return getattr(partner, 'vat', '') if partner else ''
+
+    def get_partner_address(self):
+        partner = getattr(self, 'partner_id', None)
+        if not partner:
+            return ''
+        parts = [partner.street, partner.zip, partner.city]
+        return ', '.join([p for p in parts if p])

--- a/l10n_be_fiscal_full/models/res_partner.py
+++ b/l10n_be_fiscal_full/models/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class ResPartner(models.Model):
+    _name = 'res.partner'
+    _description = 'Partner'
+
+    name = fields.Char(required=True)
+    vat = fields.Char(string='VAT Number')
+    street = fields.Char()
+    zip = fields.Char()
+    city = fields.Char()

--- a/l10n_be_fiscal_full/tests/test_belcotax_partner.py
+++ b/l10n_be_fiscal_full/tests/test_belcotax_partner.py
@@ -1,0 +1,52 @@
+import pytest
+
+
+@pytest.fixture
+def partner_class():
+    import importlib
+    from l10n_be_fiscal_full.models import res_partner
+    importlib.reload(res_partner)
+    res_partner.ResPartner._registry = []
+    res_partner.models.Model._id_seq = 1
+    return res_partner.ResPartner
+
+
+@pytest.fixture
+def belcotax_line_class():
+    import importlib
+    from l10n_be_fiscal_full.models import belcotax_line
+    importlib.reload(belcotax_line)
+    belcotax_line.BelcotaxDeclarationLine._registry = []
+    belcotax_line.models.Model._id_seq = 1
+    return belcotax_line.BelcotaxDeclarationLine
+
+
+def test_partner_helper_methods(partner_class, belcotax_line_class, fiscal_declaration_class):
+    Partner = partner_class
+    Line = belcotax_line_class
+    Declaration = fiscal_declaration_class
+
+    partner = Partner(name='Acme', vat='BE0123456789', street='Main', zip='1000', city='Brussels')
+    decl = Declaration(name='Belcotax', declaration_type='belcotax')
+    line = Line(declaration_id=decl, partner_id=partner, amount=42)
+
+    assert line.get_partner_vat() == 'BE0123456789'
+    assert line.get_partner_address() == 'Main, 1000, Brussels'
+
+
+def test_generate_belcotax_xml_contains_partner_data(partner_class, belcotax_line_class, fiscal_declaration_class):
+    Partner = partner_class
+    Line = belcotax_line_class
+    Declaration = fiscal_declaration_class
+
+    partner = Partner(name='Acme', vat='BE0123456789', street='Main', zip='1000', city='Brussels')
+    decl = Declaration(name='Belcotax', declaration_type='belcotax')
+    line = Line(declaration_id=decl, partner_id=partner, amount=99)
+
+    decl.belcotax_line_ids = [line]
+
+    decl.generate_xml()
+
+    assert 'BE0123456789' in decl.xml_content
+    assert 'Main, 1000, Brussels' in decl.xml_content
+


### PR DESCRIPTION
## Summary
- link Belcotax declaration lines with partners
- expose partner address data for XML output
- test partner helpers and XML rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcd5267588332a870330cc25b9be7