### PR TITLE
Add Belcotax submodule

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -160,3 +160,13 @@ def lu_fiscal_declaration_class():
     declaration.FiscalDeclaration._registry = []
     declaration.models.Model._id_seq = 1
     return declaration.FiscalDeclaration
+
+
+@pytest.fixture
+def belcotax_declaration_class():
+    import importlib
+    from l10n_be_fiscal_full.models import belcotax
+    importlib.reload(belcotax)
+    belcotax.BelcotaxDeclaration._registry = []
+    belcotax.models.Model._id_seq = 1
+    return belcotax.BelcotaxDeclaration

--- a/l10n_be_fiscal_full/README.rst
+++ b/l10n_be_fiscal_full/README.rst
@@ -28,3 +28,13 @@ Create and export a simple declaration programmatically::
     })
     xml = declaration.generate_xml()
     declaration.export_xml()
+
+Belcotax Submodule
+------------------
+
+The ``belcotax.declaration`` model records form 281 declarations per
+fiscal year. Use ``generate_xml`` on a record to build the XML based on
+a simplified structure. The ``export_year_form`` class method gathers all
+declarations for a given fiscal year and form type and returns the full
+XML payload. When the ``pdf_preview`` flag is passed a placeholder string
+is returned alongside the XML.

--- a/l10n_be_fiscal_full/__manifest__.py
+++ b/l10n_be_fiscal_full/__manifest__.py
@@ -6,7 +6,10 @@
     'author': 'Example Author',
     'category': 'Accounting',
     'depends': ['base'],
-    'data': [],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/belcotax_views.xml',
+    ],
     'installable': True,
     'application': True,
 }

--- a/l10n_be_fiscal_full/models/__init__.py
+++ b/l10n_be_fiscal_full/models/__init__.py
@@ -1,1 +1,2 @@
 from . import declaration
+from . import belcotax

--- a/l10n_be_fiscal_full/models/belcotax.py
+++ b/l10n_be_fiscal_full/models/belcotax.py
@@ -1,0 +1,64 @@
+from odoo import models, fields
+import xml.etree.ElementTree as ET
+
+
+class BelcotaxDeclaration(models.Model):
+    _name = 'belcotax.declaration'
+    _description = 'Belcotax Declaration'
+
+    name = fields.Char(required=True)
+    fiscal_year = fields.Char(required=True)
+    form_type = fields.Selection([
+        ('281_50', '281.50'),
+        ('281_20', '281.20'),
+    ], required=True)
+    partner_id = fields.Many2one('res.partner', string='Partner', required=True)
+    amount = fields.Float()
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('ready', 'Ready'),
+        ('exported', 'Exported')
+    ], default='draft')
+    xml_content = fields.Text(string='XML Content')
+
+    def _iterate(self):
+        """Return a list of records for uniform iteration."""
+        return self if isinstance(self, (list, tuple)) else [self]
+
+    def generate_xml(self):
+        """Generate XML for Belcotax according to simplified XSD."""
+        for rec in self._iterate():
+            root = ET.Element('BelcotaxDeclaration',
+                              year=str(rec.fiscal_year),
+                              form=rec.form_type)
+            ET.SubElement(root, 'Partner').text = getattr(rec.partner_id, 'name', '')
+            ET.SubElement(root, 'Amount').text = str(rec.amount or 0)
+            rec.xml_content = ET.tostring(root, encoding='unicode')
+            rec.state = 'ready'
+        return getattr(self, 'xml_content', None)
+
+    def export_xml(self):
+        """Mark the declaration as exported and return its XML."""
+        for rec in self._iterate():
+            if rec.state != 'ready':
+                rec.generate_xml()
+            rec.state = 'exported'
+        return getattr(self, 'xml_content', None)
+
+    @classmethod
+    def export_year_form(cls, fiscal_year, form_type, pdf_preview=False):
+        """Export declarations for a given fiscal year and form type."""
+        records = cls.search([
+            ('fiscal_year', '=', fiscal_year),
+            ('form_type', '=', form_type),
+        ])
+        for rec in records:
+            rec.export_xml()
+        root = ET.Element('Belcotax')
+        for rec in records:
+            if rec.xml_content:
+                root.append(ET.fromstring(rec.xml_content))
+        xml_result = ET.tostring(root, encoding='unicode')
+        if pdf_preview:
+            return xml_result, 'PDF preview not implemented'
+        return xml_result

--- a/l10n_be_fiscal_full/security/ir.model.access.csv
+++ b/l10n_be_fiscal_full/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_belcotax_declaration,belcotax_declaration,model_belcotax_declaration,base.group_user,1,1,1,1

--- a/l10n_be_fiscal_full/tests/test_belcotax.py
+++ b/l10n_be_fiscal_full/tests/test_belcotax.py
@@ -1,0 +1,43 @@
+import xml.etree.ElementTree as ET
+
+
+def test_generate_xml_sets_content_and_state(belcotax_declaration_class, monkeypatch):
+    Belcotax = belcotax_declaration_class
+
+    partner = type('Partner', (), {'name': 'Supplier'})()
+    dec = Belcotax(name='Test', fiscal_year='2023', form_type='281_50', partner_id=partner, amount=100.0)
+
+    dec.generate_xml()
+
+    assert dec.state == 'ready'
+    root = ET.fromstring(dec.xml_content)
+    assert root.tag == 'BelcotaxDeclaration'
+    assert root.attrib['year'] == '2023'
+
+
+def test_export_xml_marks_exported(belcotax_declaration_class):
+    Belcotax = belcotax_declaration_class
+
+    partner = type('Partner', (), {'name': 'Employee'})()
+    dec = Belcotax(name='Test', fiscal_year='2023', form_type='281_20', partner_id=partner, amount=50.0)
+
+    dec.export_xml()
+
+    assert dec.state == 'exported'
+    assert dec.xml_content.startswith('<BelcotaxDeclaration')
+
+
+def test_export_year_form_collects_records(belcotax_declaration_class):
+    Belcotax = belcotax_declaration_class
+
+    partner = type('Partner', (), {'name': 'Foo'})()
+    rec1 = Belcotax(name='One', fiscal_year='2023', form_type='281_50', partner_id=partner, amount=10)
+    rec2 = Belcotax(name='Two', fiscal_year='2023', form_type='281_50', partner_id=partner, amount=20)
+
+    xml = Belcotax.export_year_form('2023', '281_50')
+
+    root = ET.fromstring(xml)
+    assert root.tag == 'Belcotax'
+    assert len(root.findall('BelcotaxDeclaration')) == 2
+    assert rec1.state == 'exported'
+    assert rec2.state == 'exported'

--- a/l10n_be_fiscal_full/views/belcotax_views.xml
+++ b/l10n_be_fiscal_full/views/belcotax_views.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_belcotax_declaration_tree" model="ir.ui.view">
+        <field name="name">belcotax.declaration.tree</field>
+        <field name="model">belcotax.declaration</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="fiscal_year"/>
+                <field name="form_type"/>
+                <field name="partner_id"/>
+                <field name="amount"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_belcotax_declaration_form" model="ir.ui.view">
+        <field name="name">belcotax.declaration.form</field>
+        <field name="model">belcotax.declaration</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="fiscal_year"/>
+                        <field name="form_type"/>
+                        <field name="partner_id"/>
+                        <field name="amount"/>
+                        <field name="state" readonly="1"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <menuitem id="belcotax_menu" name="Belcotax"/>
+
+    <record id="action_belcotax_declaration" model="ir.actions.act_window">
+        <field name="name">Belcotax Declarations</field>
+        <field name="res_model">belcotax.declaration</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_belcotax_declaration" name="Declarations"
+              parent="belcotax_menu" action="action_belcotax_declaration"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add Belcotax declaration model under l10n_be_fiscal_full
- generate XML via ElementTree and export per fiscal year
- add views and access rights
- document Belcotax usage in README
- test new Belcotax functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcd50a31883329b3d79c9c3a2deee