### PR TITLE
Implement basic eCDF XBRL generation

### DIFF
--- a/l10n_lu_fiscal_full/README.rst
+++ b/l10n_lu_fiscal_full/README.rst
@@ -4,12 +4,13 @@ Luxembourg Fiscal Declarations
 This addon provides a minimal skeleton for handling Luxembourg fiscal
 declarations in Odoo. It defines a single model ``lu.fiscal.declaration``
 that can represent different types of filings such as VAT returns,
-client listings and other XML exports.
+client listings and other XML exports. Basic eCDF XBRL generation is
+included for demonstration purposes.
 
 The ``generate_xml`` method creates a simplistic XML snippet while
-``export_xml`` marks the declaration as exported. The implementation is
-intended as a starting point for a complete solution that would follow
-official specifications.
+``export_xml`` marks the declaration as exported. ``generate_ecdf_xbrl``
+and ``export_ecdf`` offer a lightweight example of how an XBRL document
+for the eCDF portal could be constructed.
 
 Installation
 ------------
@@ -28,3 +29,18 @@ Create and export a simple declaration programmatically::
     })
     xml = declaration.generate_xml()
     declaration.export_xml()
+
+Generate a sample eCDF XBRL document::
+
+    import json
+    data = {
+        "1000": 1000,
+        "1010": 500,
+    }
+    declaration = self.env["lu.fiscal.declaration"].create({
+        "name": "eCDF", "declaration_type": "xbrl",
+        "xbrl_taxonomy": "lu.ecdf.test",
+        "account_data": json.dumps(data),
+    })
+    xml = declaration.generate_ecdf_xbrl()
+    declaration.export_ecdf()

--- a/l10n_lu_fiscal_full/tests/test_declaration_lu.py
+++ b/l10n_lu_fiscal_full/tests/test_declaration_lu.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 
 def test_generate_xml_sets_content_and_state(lu_fiscal_declaration_class, monkeypatch):
@@ -49,3 +50,30 @@ def test_generate_and_export_on_list(lu_fiscal_declaration_class):
     assert dec2.state == 'exported'
     assert dec1.xml_content.startswith('<declaration')
     assert dec2.xml_content.startswith('<declaration')
+
+
+def test_generate_ecdf_xbrl_uses_account_data(lu_fiscal_declaration_class):
+    FiscalDeclaration = lu_fiscal_declaration_class
+    data = {"100": 10, "200": 20}
+    dec = FiscalDeclaration(
+        name='eCDF',
+        declaration_type='xbrl',
+        xbrl_taxonomy='lu.ecdf.test',
+        account_data=json.dumps(data),
+    )
+
+    xml = dec.generate_ecdf_xbrl()
+
+    assert xml.startswith('<xbrl')
+    assert "account code='100'" in xml
+    assert dec.state == 'ready'
+
+
+def test_export_ecdf_generates_when_needed(lu_fiscal_declaration_class):
+    FiscalDeclaration = lu_fiscal_declaration_class
+    dec = FiscalDeclaration(name='eCDF', declaration_type='xbrl')
+
+    dec.export_ecdf()
+
+    assert dec.state == 'exported'
+    assert dec.xml_content.startswith('<xbrl')


### PR DESCRIPTION
## Summary
- extend Luxembourg fiscal declaration model
- add fields for XBRL taxonomy and account mapping
- implement `generate_ecdf_xbrl` and `export_ecdf`
- document eCDF example in README
- test eCDF generation and export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcb407ac48332ae65d71b9d9ead18