### PR TITLE
Implement basic Belcotax model

### DIFF
--- a/l10n_be_fiscal_full/README.rst
+++ b/l10n_be_fiscal_full/README.rst
@@ -11,6 +11,15 @@ The ``generate_xml`` method creates a simplistic XML snippet while
 intended as a starting point for a complete solution that would follow
 official specifications and integrate with Intervat, Belcotax or Biztax.
 
+Belcotax 281.x
+---------------
+
+The module now includes a basic ``belcotax.declaration`` model used by the
+export wizard. A declaration stores the fiscal year, form type and partner
+information. The wizard generates a tiny XML snippet and returns it as a
+downloadable file. This is only a demonstration of the export flow and does
+not attempt to implement the official XSD.
+
 Installation
 ------------
 

--- a/l10n_be_fiscal_full/models/__init__.py
+++ b/l10n_be_fiscal_full/models/__init__.py
@@ -1,3 +1,4 @@
 from . import declaration
 from . import belcotax_line
+from . import belcotax
 from . import res_partner

--- a/l10n_be_fiscal_full/models/belcotax.py
+++ b/l10n_be_fiscal_full/models/belcotax.py
@@ -1,0 +1,48 @@
+from odoo import models, fields
+
+
+class BelcotaxDeclaration(models.Model):
+    """Simplified Belcotax declaration used in tests."""
+
+    _name = 'belcotax.declaration'
+    _description = 'Belcotax Declaration'
+
+    name = fields.Char(required=True)
+    fiscal_year = fields.Char(string='Fiscal Year', required=True)
+    form_type = fields.Selection([
+        ('281.50', '281.50'),
+        ('281.20', '281.20'),
+        ('281.10', '281.10'),
+    ], string='Form Type', required=True)
+    partner_id = fields.Many2one('res.partner', string='Partner')
+    amount = fields.Float()
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('ready', 'Ready'),
+        ('exported', 'Exported'),
+    ], default='draft')
+    exported_date = fields.Date(string='Exported On')
+    xml_content = fields.Text(string='XML Content')
+
+    def _iterate(self):
+        return self if isinstance(self, (list, tuple)) else [self]
+
+    def generate_xml(self):
+        """Create a very small XML snippet with partner and amount."""
+        for rec in self._iterate():
+            partner = getattr(rec.partner_id, 'name', '')
+            vat = getattr(rec.partner_id, 'vat', '')
+            rec.xml_content = (
+                f"<Belcotax form='{rec.form_type}' year='{rec.fiscal_year}' "
+                f"partner='{partner}' vat='{vat}' amount='{rec.amount}'/>"
+            )
+            rec.state = 'ready'
+        return getattr(self, 'xml_content', None)
+
+    def export_xml(self):
+        for rec in self._iterate():
+            if rec.state != 'ready':
+                rec.generate_xml()
+            rec.state = 'exported'
+            rec.exported_date = fields.Date.today()
+        return getattr(self, 'xml_content', None)

--- a/l10n_be_fiscal_full/tests/test_belcotax_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_belcotax_declaration.py
@@ -1,0 +1,56 @@
+import importlib
+from odoo.fields import Date
+import pytest
+
+
+@pytest.fixture
+def belcotax_declaration_class():
+    from l10n_be_fiscal_full.models import belcotax
+    importlib.reload(belcotax)
+    belcotax.BelcotaxDeclaration._registry = []
+    belcotax.models.Model._id_seq = 1
+    return belcotax.BelcotaxDeclaration
+
+
+@pytest.fixture
+def partner_class():
+    from l10n_be_fiscal_full.models import res_partner
+    importlib.reload(res_partner)
+    res_partner.ResPartner._registry = []
+    res_partner.models.Model._id_seq = 1
+    return res_partner.ResPartner
+
+
+def test_generate_xml_contains_partner_vat(belcotax_declaration_class, partner_class):
+    Partner = partner_class
+    Declaration = belcotax_declaration_class
+
+    partner = Partner(name='Foo', vat='BE0123456789')
+    dec = Declaration(
+        name='Test',
+        fiscal_year='2022',
+        form_type='281.50',
+        partner_id=partner,
+        amount=10,
+    )
+
+    dec.generate_xml()
+
+    assert dec.state == 'ready'
+    assert 'BE0123456789' in dec.xml_content
+
+
+def test_export_xml_sets_date(belcotax_declaration_class):
+    Declaration = belcotax_declaration_class
+    dec = Declaration(
+        name='Test',
+        fiscal_year='2022',
+        form_type='281.20',
+        amount=5,
+    )
+
+    dec.export_xml()
+
+    assert dec.state == 'exported'
+    assert dec.exported_date == Date.today()
+

--- a/l10n_be_fiscal_full/tests/test_wizard.py
+++ b/l10n_be_fiscal_full/tests/test_wizard.py
@@ -24,7 +24,7 @@ def test_belcotax_wizard_returns_act_url(belcotax_export_wizard_class, monkeypat
     module = __import__(Wizard.__module__, fromlist=[''])
     monkeypatch.setattr(module, 'FiscalDeclaration', DummyDeclaration)
 
-    wiz = Wizard(fiscal_year='2022', form_type='281.10')
+    wiz = Wizard(fiscal_year='2022', form_type='281.50')
     result = wiz.action_export()
 
     assert result['type'] == 'ir.actions.act_url'

--- a/l10n_be_fiscal_full/wizards/belcotax_export_wizard.py
+++ b/l10n_be_fiscal_full/wizards/belcotax_export_wizard.py
@@ -1,7 +1,7 @@
 from odoo import models, fields
 import base64
 
-from ..models.declaration import FiscalDeclaration
+from ..models.belcotax import BelcotaxDeclaration as FiscalDeclaration
 
 
 class BelcotaxExportWizard(models.Model):
@@ -10,15 +10,16 @@ class BelcotaxExportWizard(models.Model):
 
     fiscal_year = fields.Char(string='Fiscal Year', required=True)
     form_type = fields.Selection([
-        ('281.10', '281.10'),
-        ('281.30', '281.30'),
+        ('281.50', '281.50'),
+        ('281.20', '281.20'),
     ], string='Form Type', required=True)
 
     def action_export(self):
         """Generate XML and return it as a downloadable URL."""
         dec = FiscalDeclaration(
             name=f'Belcotax {self.fiscal_year}',
-            declaration_type='belcotax'
+            fiscal_year=self.fiscal_year,
+            form_type=self.form_type,
         )
         xml = dec.generate_xml()
         dec.export_xml()


### PR DESCRIPTION
## Summary
- add `belcotax.declaration` model storing partner and fiscal data
- support the new model in the Belcotax export wizard
- describe Belcotax support in the README
- test the new model and adjust wizard test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fca12beb88332ae779e2d94a202a2