### PR TITLE
Add Intervat fields and XML generator

### DIFF
--- a/l10n_be_fiscal_full/README.rst
+++ b/l10n_be_fiscal_full/README.rst
@@ -6,9 +6,12 @@ declarations in Odoo. It defines a single model ``be.fiscal.declaration``
 that can represent different types of filings such as VAT returns,
 client listings, Belcotax forms, ISOC statements and XBRL exports.
 
-The ``generate_xml`` method creates a simplistic XML snippet while
-``export_xml`` marks the declaration as exported. The implementation is
-intended as a starting point for a complete solution that would follow
+The ``generate_xml`` method originally created a simplistic XML snippet
+while ``export_xml`` merely flagged the declaration as exported. The
+model now provides basic fields for common Intervat VAT codes (00, 01,
+54…), intra‑EU operations and period information. ``generate_xml``
+produces a small ``<VATDeclaration>`` document using these values.
+This remains a lightweight example; a full solution would follow the
 official specifications and integrate with Intervat, Belcotax or Biztax.
 
 BNB/CBN XBRL
@@ -42,7 +45,12 @@ Usage Example
 Create and export a simple declaration programmatically::
 
     declaration = self.env["be.fiscal.declaration"].create({
-        "name": "VAT Return",  # or any other declaration type
+        "name": "VAT Return",
+        "declaration_type": "vat",
+        "vat_code_00": 100,
+        "vat_code_01": 50,
+        "period_type": "month",
+        "period_month": "3",
     })
     xml = declaration.generate_xml()
     declaration.export_xml()

--- a/l10n_be_fiscal_full/models/declaration.py
+++ b/l10n_be_fiscal_full/models/declaration.py
@@ -1,5 +1,6 @@
 from odoo import models, fields
 import json
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 
 class FiscalDeclaration(models.Model):
@@ -26,15 +27,50 @@ class FiscalDeclaration(models.Model):
     belcotax_line_ids = fields.One2many(
         'belcotax.declaration.line', 'declaration_id', string='Belcotax Lines'
     )
+    # VAT specific fields
+    vat_code_00 = fields.Float(string='Code 00')
+    vat_code_01 = fields.Float(string='Code 01')
+    vat_code_54 = fields.Float(string='Code 54')
+    intra_eu_sales = fields.Float(string='Intra-EU Sales')
+    intra_eu_purchases = fields.Float(string='Intra-EU Purchases')
+    exempt_sales = fields.Float(string='Exempt Sales')
+    period_type = fields.Selection([
+        ('month', 'Month'),
+        ('quarter', 'Quarter'),
+    ], default='month', string='Period Type')
+    period_month = fields.Selection(
+        [(str(i), str(i)) for i in range(1, 13)], string='Month'
+    )
+    period_quarter = fields.Selection(
+        [('Q1', 'Q1'), ('Q2', 'Q2'), ('Q3', 'Q3'), ('Q4', 'Q4')],
+        string='Quarter'
+    )
 
     def _iterate(self):
         """Return a list of records for uniform iteration."""
         return self if isinstance(self, (list, tuple)) else [self]
 
     def generate_xml(self):
-        """Generate a very basic XML representation for the declaration."""
+        """Generate an XML representation for the declaration."""
         for rec in self._iterate():
-            if rec.declaration_type == 'belcotax':
+            if rec.declaration_type == 'vat':
+                root = Element('VATDeclaration')
+                period_type = rec.__dict__.get('period_type', '')
+                SubElement(root, 'PeriodType').text = period_type or ''
+                if period_type == 'month':
+                    month = rec.__dict__.get('period_month', '')
+                    SubElement(root, 'Month').text = month or ''
+                else:
+                    quarter = rec.__dict__.get('period_quarter', '')
+                    SubElement(root, 'Quarter').text = quarter or ''
+                SubElement(root, 'VatCode00').text = str(rec.__dict__.get('vat_code_00', 0) or 0)
+                SubElement(root, 'VatCode01').text = str(rec.__dict__.get('vat_code_01', 0) or 0)
+                SubElement(root, 'VatCode54').text = str(rec.__dict__.get('vat_code_54', 0) or 0)
+                SubElement(root, 'IntraEUSales').text = str(rec.__dict__.get('intra_eu_sales', 0) or 0)
+                SubElement(root, 'IntraEUPurchases').text = str(rec.__dict__.get('intra_eu_purchases', 0) or 0)
+                SubElement(root, 'ExemptSales').text = str(rec.__dict__.get('exempt_sales', 0) or 0)
+                rec.xml_content = tostring(root, encoding='unicode')
+            elif rec.declaration_type == 'belcotax':
                 lines_xml = ''
                 for line in getattr(rec, 'belcotax_line_ids', []):
                     vat = line.get_partner_vat()

--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -9,7 +9,7 @@ def test_generate_xml_sets_content_and_state(fiscal_declaration_class, monkeypat
 
     dec.generate_xml()
 
-    assert dec.xml_content.startswith('<declaration')
+    assert dec.xml_content.startswith('<VATDeclaration')
     assert dec.state == 'ready'
 
 
@@ -21,7 +21,7 @@ def test_export_xml_marks_exported(fiscal_declaration_class, monkeypatch):
     dec.export_xml()
 
     assert dec.state == 'exported'
-    assert dec.xml_content.startswith('<declaration')
+    assert dec.xml_content.startswith('<VATDeclaration')
     assert dec.exported_date == Date.today()
 
 
@@ -42,14 +42,14 @@ def test_generate_and_export_on_list(fiscal_declaration_class):
 
     assert dec1.state == 'ready'
     assert dec2.state == 'ready'
-    assert dec1.xml_content.startswith('<declaration')
+    assert dec1.xml_content.startswith('<VATDeclaration')
     assert dec2.xml_content.startswith('<declaration')
 
     FiscalDeclaration.export_xml(records)
 
     assert dec1.state == 'exported'
     assert dec2.state == 'exported'
-    assert dec1.xml_content.startswith('<declaration')
+    assert dec1.xml_content.startswith('<VATDeclaration')
     assert dec2.xml_content.startswith('<declaration')
     assert dec1.exported_date == Date.today()
     assert dec2.exported_date == Date.today()

--- a/l10n_be_fiscal_full/tests/test_vat_xml.py
+++ b/l10n_be_fiscal_full/tests/test_vat_xml.py
@@ -1,0 +1,22 @@
+import xml.etree.ElementTree as ET
+
+
+def test_intervat_xml_contains_values(fiscal_declaration_class):
+    FiscalDeclaration = fiscal_declaration_class
+
+    dec = FiscalDeclaration(
+        name='Q1 VAT',
+        declaration_type='vat',
+        vat_code_00=100,
+        vat_code_01=50,
+        period_type='month',
+        period_month='3',
+    )
+
+    dec.generate_xml()
+
+    root = ET.fromstring(dec.xml_content)
+    assert root.tag == 'VATDeclaration'
+    assert root.findtext('VatCode00') == '100'
+    assert root.findtext('VatCode01') == '50'
+    assert root.findtext('Month') == '3'


### PR DESCRIPTION
## Summary
- add VAT code and period fields
- generate a `<VATDeclaration>` snippet
- document the fields and example usage
- update tests and add a new XML check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc85248148332af1d9142d6cf9a9f