### PR TITLE
Fix group order in social marketing security

### DIFF
--- a/social_marketing/security/social_marketing_security.xml
+++ b/social_marketing/security/social_marketing_security.xml
@@ -1,13 +1,13 @@
 <odoo>
+    <record id="group_social_marketing_editor" model="res.groups">
+        <field name="name">Social Marketing Editor</field>
+        <field name="category_id" ref="base.module_category_marketing"/>
+    </record>
+
     <record id="group_social_marketing_manager" model="res.groups">
         <field name="name">Social Marketing Manager</field>
         <field name="category_id" ref="base.module_category_marketing"/>
         <field name="implied_ids" eval="[(4, ref('group_social_marketing_editor'))]"/>
-    </record>
-
-    <record id="group_social_marketing_editor" model="res.groups">
-        <field name="name">Social Marketing Editor</field>
-        <field name="category_id" ref="base.module_category_marketing"/>
     </record>
 
     <record id="group_social_marketing_analyst" model="res.groups">


### PR DESCRIPTION
## Summary
- reorder security XML so editor group is defined before manager group
- keep the manager group implying the editor group

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737aaac5888332a438c91d3597e4af