### PR TITLE
Add module icons

### DIFF
--- a/account_anomaly/__manifest__.py
+++ b/account_anomaly/__manifest__.py
@@ -5,6 +5,7 @@
     'description': 'Simple tools to detect unusual accounting entries.',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Accounting',
+    'icon': '/account_anomaly/static/description/icon.svg',
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',

--- a/account_anomaly/static/description/icon.svg
+++ b/account_anomaly/static/description/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#cc0066"/>
+</svg>

--- a/base_plugin/__manifest__.py
+++ b/base_plugin/__manifest__.py
@@ -5,6 +5,7 @@
     'description': 'Example skeleton for an Odoo addon.',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Tools',
+    'icon': '/base_plugin/static/description/icon.svg',
     'depends': ['base'],
     'data': [
         'security/ir.model.access.csv',

--- a/base_plugin/static/description/icon.svg
+++ b/base_plugin/static/description/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#0066cc"/>
+</svg>

--- a/l10n_be_fiscal_full/__manifest__.py
+++ b/l10n_be_fiscal_full/__manifest__.py
@@ -5,6 +5,7 @@
     'description': 'Skeleton module for Belgian fiscal declarations (TVA, Belcotax, ISOC, BNB).',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Accounting',
+    'icon': '/l10n_be_fiscal_full/static/description/icon.svg',
     'depends': ['base'],
     'data': [
         'views/belcotax_wizard_views.xml',

--- a/l10n_be_fiscal_full/static/description/icon.svg
+++ b/l10n_be_fiscal_full/static/description/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#cc9900"/>
+</svg>

--- a/l10n_lu_fiscal_full/__manifest__.py
+++ b/l10n_lu_fiscal_full/__manifest__.py
@@ -5,6 +5,7 @@
     'description': 'Skeleton module for Luxembourg fiscal declarations.',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Accounting',
+    'icon': '/l10n_lu_fiscal_full/static/description/icon.svg',
     'depends': ['base'],
     'data': [],
     'installable': True,

--- a/l10n_lu_fiscal_full/static/description/icon.svg
+++ b/l10n_lu_fiscal_full/static/description/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#6600cc"/>
+</svg>

--- a/social_marketing/__manifest__.py
+++ b/social_marketing/__manifest__.py
@@ -5,6 +5,7 @@
     'description': 'Example module for scheduling posts and tracking basic metrics.',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Marketing',
+    'icon': '/social_marketing/static/description/icon.svg',
     'depends': ['base'],
     'data': [
         'security/social_marketing_security.xml',

--- a/social_marketing/static/description/icon.svg
+++ b/social_marketing/static/description/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <rect width="64" height="64" fill="#00cc66"/>
+</svg>


### PR DESCRIPTION
## Summary
- add simple SVG icons for all modules
- reference the icons in each module manifest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737eb9d0f8833298a47da158edc89b