### PR TITLE
Add ResPartnerBank test stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `conftest.py` file provides mocked versions of `odoo.models`,
 `odoo.fields` and related modules. This fake Odoo environment allows the addons
 to be imported and tested without requiring a real Odoo server. Tests execute
 entirely within this simulated setup.
+It also defines simple stub models like `ResPartnerBank` used during testing.
 
 ### Extending `conftest.py`
 

--- a/conftest.py
+++ b/conftest.py
@@ -106,6 +106,15 @@ class Model:
                 res.append(rec)
         return RecordSet(res)
 
+# Stub models
+class ResPartnerBank(Model):
+    _name = 'res.partner.bank'
+    _description = 'Bank Account'
+
+    company_id = fields_mod.Many2one('res.company')
+    partner_id = fields_mod.Many2one('res.partner')
+    acc_number = fields_mod.Char()
+
 # Modules simulés
 models_mod = types.ModuleType('odoo.models')
 models_mod.Model = Model
@@ -115,11 +124,17 @@ odoo.models = models_mod
 odoo.fields = fields_mod
 odoo.api = api_mod
 
+res_partner_bank_mod = types.ModuleType('odoo.addons.base.models.res_partner_bank')
+res_partner_bank_mod.models = models_mod
+res_partner_bank_mod.fields = fields_mod
+res_partner_bank_mod.ResPartnerBank = ResPartnerBank
+
 # Injection dans sys.modules
 sys.modules.setdefault('odoo', odoo)
 sys.modules.setdefault('odoo.models', models_mod)
 sys.modules.setdefault('odoo.fields', fields_mod)
 sys.modules.setdefault('odoo.api', api_mod)
+sys.modules.setdefault('odoo.addons.base.models.res_partner_bank', res_partner_bank_mod)
 
 
 @pytest.fixture
@@ -180,4 +195,12 @@ def bnb_xbrl_export_wizard_class():
     bnb_xbrl_export_wizard.BnbXbrlExportWizard._registry = []
     bnb_xbrl_export_wizard.models.Model._id_seq = 1
     return bnb_xbrl_export_wizard.BnbXbrlExportWizard
+
+
+@pytest.fixture
+def partner_bank_class():
+    from odoo.addons.base.models import res_partner_bank
+    res_partner_bank.ResPartnerBank._registry = []
+    res_partner_bank.models.Model._id_seq = 1
+    return res_partner_bank.ResPartnerBank
 


### PR DESCRIPTION
## Summary
- stub out a new `ResPartnerBank` model in `conftest.py`
- register the new stub module in `sys.modules`
- provide a fixture for cleaning up `ResPartnerBank`
- document the stub in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737f8035948332a83d74995d7f3b9c