### PR TITLE
Add PRINCE2 project management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains example Odoo addons.
 - `base_plugin`: Minimal plugin demonstrating the basic structure of an Odoo module.
 - `social_marketing`: Example plugin for managing social media accounts and posts with scheduling and basic tracking.
 - `account_anomaly`: Simple addon for flagging unusual accounting moves.
+- `project_prince2`: Manage projects following the PRINCE2 methodology.
 - `l10n_be_fiscal_full`: Starter module for Belgian fiscal declarations.
 - `l10n_lu_fiscal_full`: Starter module for Luxembourg fiscal declarations.
 - Make sure the scheduled action defined in [`social_marketing/data/scheduled_actions.xml`](social_marketing/data/scheduled_actions.xml) is enabled so scheduled posts are processed automatically.
@@ -15,7 +16,7 @@ For detailed installation and usage instructions, see the [user manual](docs/use
 
 ## Installation
 
-1. Copy the addon directories (e.g. `base_plugin`, `social_marketing`, `account_anomaly`) into your Odoo `addons_path`.
+1. Copy the addon directories (e.g. `base_plugin`, `social_marketing`, `account_anomaly`, `project_prince2`) into your Odoo `addons_path`.
 2. Update the Apps list inside Odoo.
 3. Install the desired addon from the Apps menu.
 

--- a/conftest.py
+++ b/conftest.py
@@ -181,3 +181,13 @@ def bnb_xbrl_export_wizard_class():
     bnb_xbrl_export_wizard.models.Model._id_seq = 1
     return bnb_xbrl_export_wizard.BnbXbrlExportWizard
 
+
+@pytest.fixture
+def prince2_project_class():
+    import importlib
+    from project_prince2.models import prince2_project
+    importlib.reload(prince2_project)
+    prince2_project.Prince2Project._registry = []
+    prince2_project.models.Model._id_seq = 1
+    return prince2_project.Prince2Project
+

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -69,3 +69,17 @@ The `l10n_lu_fiscal_full` addon mirrors the Belgian example but targets Luxembou
 
 See [l10n_lu_fiscal_full/README.rst](../l10n_lu_fiscal_full/README.rst) for details.
 
+
+## Project PRINCE2
+
+`project_prince2` introduces a minimal project model that follows the
+PRINCE2 methodology.
+
+### Usage
+
+1. Open **PRINCE2 → Projects** and create a new project.
+2. Click **Advance Stage** on the form view to move the project through
+   each stage until it reaches *Closing*.
+
+See [project_prince2/README.rst](../project_prince2/README.rst) for more
+information.

--- a/project_prince2/README.rst
+++ b/project_prince2/README.rst
@@ -1,0 +1,18 @@
+Project PRINCE2
+===============
+
+This addon provides a tiny example of managing projects using the
+PRINCE2 methodology.
+
+Installation
+------------
+
+1. Copy the ``project_prince2`` directory into your Odoo addons path.
+2. Update the app list and install **Project PRINCE2** from the Apps menu.
+
+Usage
+-----
+
+1. Navigate to **PRINCE2 → Projects** to create a project record.
+2. Use the **Advance Stage** button to move the project through each
+   PRINCE2 stage until it reaches ``Closing``.

--- a/project_prince2/__init__.py
+++ b/project_prince2/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+
+__all__ = ["models"]

--- a/project_prince2/__manifest__.py
+++ b/project_prince2/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Project PRINCE2',
+    'version': '16.0.1.0.0',
+    'summary': 'Manage projects using the PRINCE2 methodology',
+    'description': 'Example addon implementing a simplified PRINCE2 workflow.',
+    'author': 'Example Author, Thibault Ahn',
+    'category': 'Project',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/prince2_project_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/project_prince2/models/__init__.py
+++ b/project_prince2/models/__init__.py
@@ -1,0 +1,3 @@
+from . import prince2_project
+
+__all__ = ["prince2_project"]

--- a/project_prince2/models/prince2_project.py
+++ b/project_prince2/models/prince2_project.py
@@ -1,0 +1,41 @@
+from odoo import models, fields
+
+
+class Prince2Project(models.Model):
+    _name = 'project.prince2.project'
+    _description = 'PRINCE2 Project'
+
+    STAGES = [
+        'starting_up',
+        'directing',
+        'initiating',
+        'controlling',
+        'managing_delivery',
+        'managing_boundary',
+        'closing',
+    ]
+
+    name = fields.Char(required=True)
+    state = fields.Selection([
+        ('starting_up', 'Starting Up'),
+        ('directing', 'Directing'),
+        ('initiating', 'Initiating'),
+        ('controlling', 'Controlling'),
+        ('managing_delivery', 'Managing Delivery'),
+        ('managing_boundary', 'Managing Boundary'),
+        ('closing', 'Closing'),
+    ], default='starting_up')
+    company_id = fields.Many2one('res.company', required=True,
+                                 default=lambda self: self.env.company)
+
+    def __init__(self, **vals):
+        vals.setdefault('state', 'starting_up')
+        super().__init__(**vals)
+
+    def advance_stage(self):
+        stages = self.STAGES
+        projects = self if isinstance(self, (list, tuple)) else [self]
+        for project in projects:
+            idx = stages.index(project.state)
+            if idx < len(stages) - 1:
+                project.state = stages[idx + 1]

--- a/project_prince2/security/ir.model.access.csv
+++ b/project_prince2/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_prince2_project,access_prince2_project,model_project_prince2_project,base.group_user,1,1,1,1

--- a/project_prince2/tests/test_prince2_workflow.py
+++ b/project_prince2/tests/test_prince2_workflow.py
@@ -1,0 +1,11 @@
+
+def test_advance_stage_moves_until_closing(prince2_project_class):
+    Project = prince2_project_class
+    proj = Project(name='Demo')
+
+    for stage in Project.STAGES[1:]:
+        proj.advance_stage()
+        assert proj.state == stage
+
+    proj.advance_stage()
+    assert proj.state == Project.STAGES[-1]

--- a/project_prince2/views/prince2_project_views.xml
+++ b/project_prince2/views/prince2_project_views.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_prince2_project_tree" model="ir.ui.view">
+        <field name="name">project.prince2.project.tree</field>
+        <field name="model">project.prince2.project</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_prince2_project_form" model="ir.ui.view">
+        <field name="name">project.prince2.project.form</field>
+        <field name="model">project.prince2.project</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="state"/>
+                    </group>
+                    <footer>
+                        <button name="advance_stage" type="object" string="Advance Stage" class="btn-primary"/>
+                    </footer>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <menuitem id="project_prince2_menu" name="PRINCE2"/>
+    <menuitem id="project_prince2_menu_root" name="Projects" parent="project_prince2_menu"/>
+    <record id="action_prince2_project" model="ir.actions.act_window">
+        <field name="name">PRINCE2 Projects</field>
+        <field name="res_model">project.prince2.project</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem id="menu_prince2_project" name="Projects" parent="project_prince2_menu_root" action="action_prince2_project"/>
+</odoo>


### PR DESCRIPTION
## Summary
- implement a new addon `project_prince2`
- create PRINCE2 project model and views
- document usage in README and user manual
- update README module list and installation instructions
- provide tests and fixture for the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737efd33a083328bf58405dc836cbe