### PR TITLE
Integrate PRINCE2 with Odoo Project

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -112,6 +112,13 @@ class ResPartnerBank(Model):
     partner_id = fields_mod.Many2one('res.partner')
     acc_number = fields_mod.Char()
 
+# Minimal Project stub used for linking PRINCE2 records
+class Project(Model):
+    _name = 'project.project'
+    _description = 'Project'
+
+    name = fields_mod.Char()
+
 # Modules simulés
 models_mod = types.ModuleType('odoo.models')
 models_mod.Model = Model
@@ -126,12 +133,22 @@ res_partner_bank_mod.models = models_mod
 res_partner_bank_mod.fields = fields_mod
 res_partner_bank_mod.ResPartnerBank = ResPartnerBank
 
+project_mod = types.ModuleType('odoo.addons.project.models.project')
+project_mod.models = models_mod
+project_mod.fields = fields_mod
+project_mod.Project = Project
+sys.modules.setdefault('odoo.addons', types.ModuleType('odoo.addons'))
+sys.modules.setdefault('odoo.addons.project', types.ModuleType('project'))
+sys.modules.setdefault('odoo.addons.project.models', types.ModuleType('models'))
+sys.modules['odoo.addons.project.models'].project = project_mod
+
 # Injection dans sys.modules
 sys.modules.setdefault('odoo', odoo)
 sys.modules.setdefault('odoo.models', models_mod)
 sys.modules.setdefault('odoo.fields', fields_mod)
 sys.modules.setdefault('odoo.api', api_mod)
 sys.modules.setdefault('odoo.addons.base.models.res_partner_bank', res_partner_bank_mod)
+sys.modules.setdefault('odoo.addons.project.models.project', project_mod)
 
 # Fixtures
 @pytest.fixture
@@ -203,3 +220,11 @@ def partner_bank_class():
     res_partner_bank.ResPartnerBank._registry = []
     res_partner_bank.models.Model._id_seq = 1
     return res_partner_bank.ResPartnerBank
+
+
+@pytest.fixture
+def project_class():
+    from odoo.addons.project.models import project
+    project.Project._registry = []
+    project.models.Model._id_seq = 1
+    return project.Project

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -73,7 +73,8 @@ See [l10n_lu_fiscal_full/README.rst](../l10n_lu_fiscal_full/README.rst) for deta
 ## Project PRINCE2
 
 `project_prince2` introduces a minimal project model that follows the
-PRINCE2 methodology.
+PRINCE2 methodology. Each PRINCE2 project can optionally link to a
+regular project via the *Linked Project* field.
 
 ### Usage
 

--- a/project_prince2/README.rst
+++ b/project_prince2/README.rst
@@ -2,7 +2,8 @@ Project PRINCE2
 ===============
 
 This addon provides a tiny example of managing projects using the
-PRINCE2 methodology.
+PRINCE2 methodology. It can also link each PRINCE2 record to a
+standard ``project.project`` using the *Linked Project* field.
 
 Installation
 ------------

--- a/project_prince2/__manifest__.py
+++ b/project_prince2/__manifest__.py
@@ -5,7 +5,7 @@
     'description': 'Example addon implementing a simplified PRINCE2 workflow.',
     'author': 'Example Author, Thibault Ahn',
     'category': 'Project',
-    'depends': ['base'],
+    'depends': ['base', 'project'],
     'data': [
         'security/ir.model.access.csv',
         'views/prince2_project_views.xml',

--- a/project_prince2/models/prince2_project.py
+++ b/project_prince2/models/prince2_project.py
@@ -27,6 +27,7 @@ class Prince2Project(models.Model):
     ], default='starting_up')
     company_id = fields.Many2one('res.company', required=True,
                                  default=lambda self: self.env.company)
+    project_id = fields.Many2one('project.project', string='Linked Project')
 
     def __init__(self, **vals):
         vals.setdefault('state', 'starting_up')

--- a/project_prince2/tests/test_prince2_workflow.py
+++ b/project_prince2/tests/test_prince2_workflow.py
@@ -9,3 +9,13 @@ def test_advance_stage_moves_until_closing(prince2_project_class):
 
     proj.advance_stage()
     assert proj.state == Project.STAGES[-1]
+
+
+def test_project_link_stores_reference(prince2_project_class, project_class):
+    Prince2 = prince2_project_class
+    Project = project_class
+
+    linked = Project(name='Standard')
+    prince2 = Prince2(name='Demo PR2', project_id=linked)
+
+    assert prince2.project_id is linked

--- a/project_prince2/views/prince2_project_views.xml
+++ b/project_prince2/views/prince2_project_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name"/>
+                <field name="project_id"/>
                 <field name="state"/>
             </tree>
         </field>
@@ -19,6 +20,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="project_id"/>
                         <field name="state"/>
                     </group>
                     <footer>


### PR DESCRIPTION
## Summary
- allow linking PRINCE2 records to `project.project`
- display the new field in the views
- update documentation about the integration
- provide a `project` model stub for tests
- test linking a PRINCE2 record to a project

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873829f2de08332a82df989f02bc495