### PR TITLE
Add anomaly scanner with cross-module checks

### DIFF
--- a/account_anomaly/models/__init__.py
+++ b/account_anomaly/models/__init__.py
@@ -1,3 +1,3 @@
-from . import account_move
+from . import account_move, scanner
 
-__all__ = ["account_move"]
+__all__ = ["account_move", "scanner"]

--- a/account_anomaly/models/scanner.py
+++ b/account_anomaly/models/scanner.py
@@ -1,0 +1,70 @@
+from odoo import models, fields
+
+
+class AnomalyScanner(models.Model):
+    """Aggregate simple consistency checks across modules."""
+
+    _name = 'anomaly.scanner'
+    _description = 'Anomaly Scanner'
+
+    @staticmethod
+    def scan_all():
+        """Return a list describing all detected issues."""
+        issues = []
+
+        # Duplicate bank accounts
+        try:
+            from odoo.addons.base.models import res_partner_bank
+            seen = {}
+            for rec in res_partner_bank.ResPartnerBank._registry:
+                num = getattr(rec, 'acc_number', None)
+                if not num:
+                    continue
+                seen.setdefault(num, []).append(rec)
+            for num, recs in seen.items():
+                if len(recs) > 1:
+                    issues.append({
+                        'model': 'res.partner.bank',
+                        'issue': 'duplicate_acc_number',
+                        'acc_number': num,
+                        'ids': [r.id for r in recs],
+                    })
+        except Exception:
+            pass
+
+        # Scheduled posts still pending in the past
+        try:
+            from social_marketing.models import social_post
+            now = fields.Datetime.now()
+            for post in social_post.SocialPost._registry:
+                date = getattr(post, 'scheduled_date', None)
+                if post.state == 'scheduled' and date and date <= now:
+                    issues.append({
+                        'model': 'social.marketing.post',
+                        'issue': 'overdue_post',
+                        'id': post.id,
+                    })
+        except Exception:
+            pass
+
+        # Exported declarations missing exported_date
+        decl_sources = [
+            ('l10n_be_fiscal_full.models.declaration', 'FiscalDeclaration'),
+            ('l10n_be_fiscal_full.models.belcotax', 'BelcotaxDeclaration'),
+            ('l10n_lu_fiscal_full.models.declaration', 'FiscalDeclaration'),
+        ]
+        for module_name, cls_name in decl_sources:
+            try:
+                module = __import__(module_name, fromlist=[cls_name])
+                Cls = getattr(module, cls_name)
+            except Exception:
+                continue
+            for rec in Cls._registry:
+                if getattr(rec, 'state', None) == 'exported' and not getattr(rec, 'exported_date', None):
+                    issues.append({
+                        'model': Cls._name,
+                        'issue': 'missing_exported_date',
+                        'id': rec.id,
+                    })
+
+        return issues

--- a/account_anomaly/tests/test_scanner.py
+++ b/account_anomaly/tests/test_scanner.py
@@ -1,0 +1,57 @@
+import datetime
+import importlib
+
+
+def get_scanner():
+    from account_anomaly.models import scanner
+    importlib.reload(scanner)
+    return scanner.AnomalyScanner
+
+
+def test_scanner_detects_duplicate_bank(partner_bank_class):
+    Bank = partner_bank_class
+    b1 = Bank(acc_number='ABC')
+    b2 = Bank(acc_number='ABC')
+
+    Scanner = get_scanner()
+    issues = Scanner.scan_all()
+
+    assert any(i.get('issue') == 'duplicate_acc_number' and i.get('acc_number') == 'ABC' for i in issues)
+    assert any(b1.id in i.get('ids', []) and b2.id in i.get('ids', []) for i in issues)
+
+
+def test_scanner_detects_overdue_posts(social_post_class, monkeypatch):
+    SocialPost = social_post_class
+    post = SocialPost(
+        name='late',
+        account_id=None,
+        content='x',
+        scheduled_date=datetime.datetime.now() - datetime.timedelta(days=1),
+        state='scheduled',
+        stats_impressions=0,
+        stats_clicks=0,
+    )
+
+    monkeypatch.setattr(SocialPost, 'search', lambda self, domain: [post], raising=False)
+
+    Scanner = get_scanner()
+    issues = Scanner.scan_all()
+
+    assert any(i.get('issue') == 'overdue_post' and i.get('id') == post.id for i in issues)
+
+
+def test_scanner_detects_missing_export_date(fiscal_declaration_class, lu_fiscal_declaration_class):
+    BEDecl = fiscal_declaration_class
+    LUDecl = lu_fiscal_declaration_class
+
+    be = BEDecl(name='BE', declaration_type='vat', state='exported', exported_date=None)
+    lu = LUDecl(name='LU', declaration_type='vat', state='exported')
+
+    Scanner = get_scanner()
+    issues = Scanner.scan_all()
+
+    be_issue = any(i.get('model') == BEDecl._name and i.get('issue') == 'missing_exported_date' and i.get('id') == be.id for i in issues)
+    lu_issue = any(i.get('model') == LUDecl._name and i.get('issue') == 'missing_exported_date' and i.get('id') == lu.id for i in issues)
+
+    assert be_issue
+    assert lu_issue

--- a/conftest.py
+++ b/conftest.py
@@ -133,6 +133,10 @@ res_partner_bank_mod.models = models_mod
 res_partner_bank_mod.fields = fields_mod
 res_partner_bank_mod.ResPartnerBank = ResPartnerBank
 
+sys.modules.setdefault('odoo.addons.base', types.ModuleType('base'))
+sys.modules.setdefault('odoo.addons.base.models', types.ModuleType('models'))
+sys.modules['odoo.addons.base.models'].res_partner_bank = res_partner_bank_mod
+
 project_mod = types.ModuleType('odoo.addons.project.models.project')
 project_mod.models = models_mod
 project_mod.fields = fields_mod


### PR DESCRIPTION
## Summary
- create `anomaly.scanner` utility to aggregate issues
- wire scanner into module init
- expose stub base modules in `conftest`
- test scanner for duplicate bank accounts, overdue posts and missing export dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738673f7108332a232d1091b2ba811