### PR TITLE
Add validation on Belgian VAT declaration fields

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -151,6 +151,11 @@ sys.modules.setdefault('odoo', odoo)
 sys.modules.setdefault('odoo.models', models_mod)
 sys.modules.setdefault('odoo.fields', fields_mod)
 sys.modules.setdefault('odoo.api', api_mod)
+exceptions_mod = types.ModuleType('odoo.exceptions')
+class ValidationError(Exception):
+    pass
+exceptions_mod.ValidationError = ValidationError
+sys.modules.setdefault('odoo.exceptions', exceptions_mod)
 sys.modules.setdefault('odoo.addons.base.models.res_partner_bank', res_partner_bank_mod)
 sys.modules.setdefault('odoo.addons.project.models.project', project_mod)
 

--- a/l10n_be_fiscal_full/models/declaration.py
+++ b/l10n_be_fiscal_full/models/declaration.py
@@ -1,4 +1,5 @@
-from odoo import models, fields
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
 import json
 from xml.etree.ElementTree import Element, SubElement, tostring
 
@@ -45,6 +46,22 @@ class FiscalDeclaration(models.Model):
         [('Q1', 'Q1'), ('Q2', 'Q2'), ('Q3', 'Q3'), ('Q4', 'Q4')],
         string='Quarter'
     )
+
+    @api.constrains(
+        'vat_code_00', 'vat_code_01', 'vat_code_54',
+        'intra_eu_sales', 'intra_eu_purchases', 'exempt_sales'
+    )
+    def _check_positive_values(self):
+        for rec in self._iterate():
+            for field_name in [
+                'vat_code_00', 'vat_code_01', 'vat_code_54',
+                'intra_eu_sales', 'intra_eu_purchases', 'exempt_sales',
+            ]:
+                value = getattr(rec, field_name, 0)
+                if value is not None and value < 0:
+                    raise ValidationError(
+                        f"{field_name} must be a positive number"
+                    )
 
     def _iterate(self):
         """Return a list of records for uniform iteration."""

--- a/l10n_be_fiscal_full/tests/test_declaration.py
+++ b/l10n_be_fiscal_full/tests/test_declaration.py
@@ -1,5 +1,6 @@
 import pytest
 from odoo.fields import Date
+from odoo.exceptions import ValidationError
 
 
 def test_generate_xml_sets_content_and_state(fiscal_declaration_class, monkeypatch):
@@ -53,3 +54,16 @@ def test_generate_and_export_on_list(fiscal_declaration_class):
     assert dec2.xml_content.startswith('<declaration')
     assert dec1.exported_date == Date.today()
     assert dec2.exported_date == Date.today()
+
+
+def test_negative_values_raise_validation_error(fiscal_declaration_class):
+    FiscalDeclaration = fiscal_declaration_class
+
+    dec = FiscalDeclaration(
+        name='Q1 VAT',
+        declaration_type='vat',
+        vat_code_00=-5,
+    )
+
+    with pytest.raises(ValidationError):
+        dec._check_positive_values()


### PR DESCRIPTION
## Summary
- enforce positive numbers for Belgian VAT fields with a constraint
- expose a `ValidationError` in the Odoo test stubs
- test the new validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c77536af08332a392ace82a1d6f87