### PR TITLE
Add export date to LU declaration

### DIFF
--- a/account_anomaly/tests/test_scanner.py
+++ b/account_anomaly/tests/test_scanner.py
@@ -45,7 +45,7 @@ def test_scanner_detects_missing_export_date(fiscal_declaration_class, lu_fiscal
     LUDecl = lu_fiscal_declaration_class
 
     be = BEDecl(name='BE', declaration_type='vat', state='exported', exported_date=None)
-    lu = LUDecl(name='LU', declaration_type='vat', state='exported')
+    lu = LUDecl(name='LU', declaration_type='vat', state='exported', exported_date=None)
 
     Scanner = get_scanner()
     issues = Scanner.scan_all()

--- a/l10n_lu_fiscal_full/models/declaration.py
+++ b/l10n_lu_fiscal_full/models/declaration.py
@@ -19,6 +19,7 @@ class FiscalDeclaration(models.Model):
         ('ready', 'Ready'),
         ('exported', 'Exported')
     ], default='draft')
+    exported_date = fields.Date(string='Exported On')
     xml_content = fields.Text(string='XML Content')
     xbrl_taxonomy = fields.Char(string='XBRL Taxonomy')
     account_data = fields.Text(string='Account Mapping')
@@ -70,4 +71,5 @@ class FiscalDeclaration(models.Model):
             if rec.state != 'ready':
                 rec.generate_ecdf_xbrl()
             rec.state = 'exported'
+            rec.exported_date = fields.Date.today()
         return getattr(self, 'xml_content', None)

--- a/l10n_lu_fiscal_full/tests/test_declaration_lu.py
+++ b/l10n_lu_fiscal_full/tests/test_declaration_lu.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+from odoo.fields import Date
 
 
 def test_generate_xml_sets_content_and_state(lu_fiscal_declaration_class, monkeypatch):
@@ -77,3 +78,4 @@ def test_export_ecdf_generates_when_needed(lu_fiscal_declaration_class):
 
     assert dec.state == 'exported'
     assert dec.xml_content.startswith('<xbrl')
+    assert dec.exported_date == Date.today()


### PR DESCRIPTION
## Summary
- track export dates for LU fiscal declarations
- update ECDF export to store the date
- check exported_date in LU declaration tests
- adjust scanner test for new LU field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c775473588332b6f6f8291c2d4a15