### PR TITLE
lu: track XML export date

### DIFF
--- a/l10n_lu_fiscal_full/models/declaration.py
+++ b/l10n_lu_fiscal_full/models/declaration.py
@@ -43,6 +43,7 @@ class FiscalDeclaration(models.Model):
             if rec.state != 'ready':
                 rec.generate_xml()
             rec.state = 'exported'
+            rec.exported_date = fields.Date.today()
         return getattr(self, 'xml_content', None)
 
     def generate_ecdf_xbrl(self):

--- a/l10n_lu_fiscal_full/tests/test_declaration_lu.py
+++ b/l10n_lu_fiscal_full/tests/test_declaration_lu.py
@@ -23,6 +23,7 @@ def test_export_xml_marks_exported(lu_fiscal_declaration_class, monkeypatch):
 
     assert dec.state == 'exported'
     assert dec.xml_content.startswith('<declaration')
+    assert dec.exported_date == Date.today()
 
 
 def test_generate_and_export_on_list(lu_fiscal_declaration_class):
@@ -51,6 +52,8 @@ def test_generate_and_export_on_list(lu_fiscal_declaration_class):
     assert dec2.state == 'exported'
     assert dec1.xml_content.startswith('<declaration')
     assert dec2.xml_content.startswith('<declaration')
+    assert dec1.exported_date == Date.today()
+    assert dec2.exported_date == Date.today()
 
 
 def test_generate_ecdf_xbrl_uses_account_data(lu_fiscal_declaration_class):


### PR DESCRIPTION
## Summary
- track exported date when exporting fiscal declarations to XML
- test exported date is recorded for single and multi-record exports

## Testing
- `pytest l10n_lu_fiscal_full/tests/test_declaration_lu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68906998bc5083328df43a3a99246d1b