### PR TITLE
Refactor state selection to derive from STAGES list

### DIFF
--- a/project_prince2/models/prince2_project.py
+++ b/project_prince2/models/prince2_project.py
@@ -16,21 +16,16 @@ class Prince2Project(models.Model):
     ]
 
     name = fields.Char(required=True)
-    state = fields.Selection([
-        ('starting_up', 'Starting Up'),
-        ('directing', 'Directing'),
-        ('initiating', 'Initiating'),
-        ('controlling', 'Controlling'),
-        ('managing_delivery', 'Managing Delivery'),
-        ('managing_boundary', 'Managing Boundary'),
-        ('closing', 'Closing'),
-    ], default='starting_up')
+    state = fields.Selection(
+        [(stage, stage.replace('_', ' ').title()) for stage in STAGES],
+        default=STAGES[0],
+    )
     company_id = fields.Many2one('res.company', required=True,
                                  default=lambda self: self.env.company)
     project_id = fields.Many2one('project.project', string='Linked Project')
 
     def __init__(self, **vals):
-        vals.setdefault('state', 'starting_up')
+        vals.setdefault('state', self.STAGES[0])
         super().__init__(**vals)
 
     def advance_stage(self):


### PR DESCRIPTION
## Summary
- build project state selection list dynamically from defined stages
- use first stage as default state

## Testing
- `pytest project_prince2/tests/test_prince2_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_6890699ade60833292d69c26a06ed810