### PR TITLE
refactor social post scheduling

### DIFF
--- a/social_marketing/models/social_post.py
+++ b/social_marketing/models/social_post.py
@@ -44,22 +44,14 @@ class SocialPost(models.Model):
         company. All matching records are then published via
         :meth:`post_now`.
         """
+        now = fields.Datetime.now()
         domain = [
             ('state', '=', 'scheduled'),
-            ('scheduled_date', '<=', fields.Datetime.now()),
+            ('scheduled_date', '<=', now),
         ]
         if getattr(self, 'env', None):
             domain.append(('company_id', '=', self.env.company.id))
 
         posts = self.search(domain)
-
-        if hasattr(posts, 'post_now'):
-            posts.post_now()
-        else:
-            now = fields.Datetime.now()
-            filtered = [
-                p for p in posts
-                if p.state == 'scheduled' and p.scheduled_date <= now
-            ]
-            self.__class__.post_now(filtered)
+        posts.post_now()
 

--- a/social_marketing/tests/test_posting.py
+++ b/social_marketing/tests/test_posting.py
@@ -1,7 +1,7 @@
 import datetime
 
 
-def test_run_scheduled_posts_posts_due_items(social_post_class, monkeypatch):
+def test_run_scheduled_posts_posts_due_items(social_post_class):
     SocialPost = social_post_class
 
     post = SocialPost(
@@ -12,18 +12,17 @@ def test_run_scheduled_posts_posts_due_items(social_post_class, monkeypatch):
         state='scheduled',
         stats_impressions=0,
         stats_clicks=0,
+        company_id=1,
     )
 
-    monkeypatch.setattr(SocialPost, 'search', lambda self, domain: [post], raising=False)
-
-    SocialPost().run_scheduled_posts()
+    SocialPost.run_scheduled_posts(SocialPost)
 
     assert post.state == 'posted'
     assert post.stats_impressions == 1
     assert post.stats_clicks == 1
 
 
-def test_run_scheduled_posts_ignores_future_items(social_post_class, monkeypatch):
+def test_run_scheduled_posts_ignores_future_items(social_post_class):
     SocialPost = social_post_class
 
     post = SocialPost(
@@ -34,11 +33,10 @@ def test_run_scheduled_posts_ignores_future_items(social_post_class, monkeypatch
         state='scheduled',
         stats_impressions=0,
         stats_clicks=0,
+        company_id=1,
     )
 
-    monkeypatch.setattr(SocialPost, 'search', lambda self, domain: [post], raising=False)
-
-    SocialPost().run_scheduled_posts()
+    SocialPost.run_scheduled_posts(SocialPost)
 
     assert post.state == 'scheduled'
     assert post.stats_impressions == 0


### PR DESCRIPTION
## Summary
- centralize scheduling time retrieval for social posts
- simplify scheduled post publishing workflow
- update tests for new scheduling logic

## Testing
- `pytest social_marketing/tests/test_posting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890699db8548332abd9eb2e2d08d9ce