### PR TITLE
Set default stats for social marketing posts

### DIFF
--- a/social_marketing/models/social_post.py
+++ b/social_marketing/models/social_post.py
@@ -19,8 +19,8 @@ class SocialPost(models.Model):
         ('scheduled', 'Scheduled'),
         ('posted', 'Posted')
     ], default='draft')
-    stats_impressions = fields.Integer(string='Impressions')
-    stats_clicks = fields.Integer(string='Clicks')
+    stats_impressions = fields.Integer(string='Impressions', default=0)
+    stats_clicks = fields.Integer(string='Clicks', default=0)
     company_id = fields.Many2one('res.company', required=True,
                                  default=lambda self: self.env.company)
 


### PR DESCRIPTION
## Summary
- default `stats_impressions` and `stats_clicks` to 0 in social posts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890699ebcac8332b38f9582c09af428