### PR TITLE
Reset anomaly flag for normal account moves

### DIFF
--- a/account_anomaly/models/account_move.py
+++ b/account_anomaly/models/account_move.py
@@ -18,4 +18,6 @@ class AccountMove(models.Model):
             if rec.amount < 0 or rec.amount > threshold:
                 rec.is_anomaly = True
                 anomalies.append(rec)
+            else:
+                rec.is_anomaly = False
         return anomalies

--- a/account_anomaly/tests/test_anomaly_detection.py
+++ b/account_anomaly/tests/test_anomaly_detection.py
@@ -14,6 +14,7 @@ def test_find_anomalies_detects_unusual_moves(account_move_class):
     assert ok not in result
     assert neg.is_anomaly is True
     assert big.is_anomaly is True
+    assert ok.is_anomaly is False
 
 
 def test_find_anomalies_uses_threshold(account_move_class):
@@ -24,3 +25,17 @@ def test_find_anomalies_uses_threshold(account_move_class):
 
     assert mid in result
     assert mid.is_anomaly is True
+
+
+def test_find_anomalies_resets_flag(account_move_class):
+    AccountMove = account_move_class
+    mov = AccountMove(name='mov', amount=20000, date=datetime.date.today())
+
+    AccountMove.find_anomalies()
+    assert mov.is_anomaly is True
+
+    mov.amount = 100
+    result = AccountMove.find_anomalies()
+
+    assert mov not in result
+    assert mov.is_anomaly is False


### PR DESCRIPTION
## Summary
- Ensure `find_anomalies` clears `is_anomaly` on moves within thresholds
- Add tests confirming anomaly flag resets for compliant and previously anomalous moves

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890699c8bdc83328c7005a05916c16e